### PR TITLE
Restored Estimator class in pycompwa interface

### DIFF
--- a/PyComPWA.cpp
+++ b/PyComPWA.cpp
@@ -390,8 +390,10 @@ PYBIND11_MODULE(ui, m) {
 
   //------- Estimator + Optimizer
 
-  py::class_<ComPWA::FunctionTree::FunctionTreeEstimator>(
-      m, "FunctionTreeEstimator")
+  py::class_<ComPWA::Estimator::Estimator<double>>(m, "Estimator");
+
+  py::class_<ComPWA::FunctionTree::FunctionTreeEstimator,
+             ComPWA::Estimator::Estimator<double>>(m, "FunctionTreeEstimator")
       .def("print", &ComPWA::FunctionTree::FunctionTreeEstimator::print,
            "print function tree");
 


### PR DESCRIPTION
See the line `py::class_<ComPWA::Estimator::Estimator<double>>(m, "Estimator");` that was removed in #22. This caused the `Quickstart` to crash.

*Note that this means our unit tests are insufficient*: apparently, not all functionality that is used in the Quickstart is tested.