### PR TITLE
Improvements for the ComPWA python UI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ jobs:
         homebrew:
           packages:
             - boost
-            - gsl
             - python3
             - pip3
       env:
@@ -42,7 +41,6 @@ jobs:
           update: true
           packages:
             - libboost-all-dev
-            - libgsl0-dev
             - python3
             - python3-pip
             - python3-venv

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -5,4 +5,7 @@ Examples
 
 .. _example_quickstart:
 .. include:: _examples/Quickstart.rst
+.. _example_datainput:
+.. include:: _examples/DataInput.rst
+.. _example_importancesampling:
 .. include:: _examples/ImportanceSampling.rst

--- a/doc/source/python-ui.rst
+++ b/doc/source/python-ui.rst
@@ -28,12 +28,32 @@ wave analysis:
 Read and Write Data Samples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Currently only the reading and writing of ROOT files is supported via the
+For python users it is recommended to first load the data into a common format
+via numpy or pandas and then construct :class:`.Event` s and 
+:class:`.Particle` s.
+
+.. autoclass:: pycompwa.ui.Event
+   :members:
+   :undoc-members:
+   :noindex:
+
+.. autoclass:: pycompwa.ui.Particle
+   :members:
+   :undoc-members:
+   :noindex:
+
+The procedure is explained :ref:`here<example_datainput>` in more detail.
+
+Alternatively, the reading and writing of ROOT files is supported via the
 :class:`.RootDataIO` class.
 
 .. autoclass:: pycompwa.ui.RootDataIO
    :members:
    :noindex:
+
+.. tip::
+   Because this class assumes a predefined structure in the ROOT file, the
+   previous method via Events and Particles is more flexible and recommended.
 
 For the reading of data/events a predefined tree structure is assumed. The name
 of the tree inside the file and the number of events to process can be by 
@@ -113,11 +133,13 @@ Loading and Defining Particles
 Particles can loaded and stored inside a :class:`.PartList`. 
 
 .. autofunction:: pycompwa.ui.read_particles
+   :noindex:
 
 Also particles can be inserted to an existing :class:`.PartList`, overwriting
 already existing particles.
 
 .. autofunction:: pycompwa.ui.insert_particles
+   :noindex:
 
 .. _create-kin-and-intens:
 

--- a/examples/jupyter/DataInput.ipynb
+++ b/examples/jupyter/DataInput.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Importing Data\n",
+    "---------------------\n",
+    "\n",
+    "This notebook shows how to conveniently input your data into ComPWA using the python interface!\n",
+    "Also it shows how to calculate kinematic variables."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    ".. note::\n",
+    "   In this example the data is loaded from a ROOT file via `uproot <https://github.com/scikit-hep/uproot>`__, this part can of course be exchanged by your data format."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pycompwa.ui as pwa\n",
+    "import uproot\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we can start, a dummy root data file has to be created. Normally you would skip the next step, since you already have a data file that you want to import."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with uproot.recreate(\"tuples.root\") as f:\n",
+    "    f[\"data\"] = uproot.newtree({\"D0.px\": \"float64\",\n",
+    "                                \"D0.py\": \"float64\",\n",
+    "                                \"D0.pz\": \"float64\",\n",
+    "                                \"D0.E\": \"float64\",\n",
+    "                                \"Dm.px\": \"float64\",\n",
+    "                                \"Dm.py\": \"float64\",\n",
+    "                                \"Dm.pz\": \"float64\",\n",
+    "                                \"Dm.E\": \"float64\",\n",
+    "                                \"pip.px\": \"float64\",\n",
+    "                                \"pip.py\": \"float64\",\n",
+    "                                \"pip.pz\": \"float64\",\n",
+    "                                \"pip.E\": \"float64\"\n",
+    "                               })\n",
+    "    f[\"data\"].extend({\"D0.px\": np.array([-0.63207397,  0.11329174, -0.32988257]),\n",
+    "                      \"D0.py\": np.array([-0.02727499,  0.39965045, 0.1848439 ]),\n",
+    "                      \"D0.pz\": np.array([ 0.16475981,  0.28701658, -0.37938268]),\n",
+    "                      \"D0.E\": np.array([2.0180088, 1.92316975, 1.93920292]),\n",
+    "                      \"Dm.px\": np.array([0.48782456, 0.08336758, 0.10971082]),\n",
+    "                      \"Dm.py\": np.array([-0.10812153, -0.56649819, -0.13254077]),\n",
+    "                      \"Dm.pz\": np.array([-0.12110724, -0.35891476, 0.44891566]),\n",
+    "                      \"Dm.E\": np.array([1.95351745, 1.96315494, 1.94968155]),\n",
+    "                      \"pip.px\": np.array([ 0.16118203, -0.10011399, 0.24527202]),\n",
+    "                      \"pip.py\": np.array([ 0.10152041, 0.19745644, -0.04717316]),\n",
+    "                      \"pip.pz\": np.array([-0.03064159, 0.0802533, -0.04723599]),\n",
+    "                      \"pip.E\": np.array([0.23812766, 0.27373762, 0.28999094])\n",
+    "                     })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First load the data from the root file and bundle the 4 vector data in numpy arrays"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tree = uproot.open(\"tuples.root\")[\"data\"]\n",
+    "parts = tree.arrays(['D0*', 'Dm*', 'pip*'])\n",
+    "D0s = np.array((parts[b'D0.px'],parts[b'D0.py'],parts[b'D0.pz'],parts[b'D0.E'])).T\n",
+    "Dms = np.array((parts[b'Dm.px'],parts[b'Dm.py'],parts[b'Dm.pz'],parts[b'Dm.E'])).T\n",
+    "pis = np.array((parts[b'pip.px'],parts[b'pip.py'],parts[b'pip.pz'],parts[b'pip.E'])).T"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now construct ComPWA `Event`s by handing it a list of `Particle`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evts = pwa.EventList(\n",
+    "    [pwa.Event(pwa.ParticleList([pwa.Particle(x[0], 421), pwa.Particle(x[1], -411), pwa.Particle(x[2], 211)]))\n",
+    "     for x in zip(D0s, Dms, pis)])\n",
+    "print(\"Event 0:\",evts[0].particle_list)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "That's it! At this point you successfully imported your data into ComPWA and are ready to do PWA! Alternatively the `RootDataIO` class can be used. More info about this in the :ref:`docs<dataio>`.\n",
+    "\n",
+    "\n",
+    "You can proceed with other tasks. Below it is shown how to calculate the kinematic variables from an `Event`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partlist = pwa.read_particles('../../ComPWA/Physics/particle_list.xml')\n",
+    "kin = pwa.HelicityKinematics(partlist, [421], [421, -411, 211])\n",
+    "kin.create_all_subsystems()\n",
+    "\n",
+    "kin.get_kinematic_variable_names()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the `Kinematics.convert()` function the `Event` can be converted to a `DataPoint`, which contains all of the kinematic variables listed above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "point = kin.convert(evts[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(point.kinematic_variables)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/angular-distribution-tests/EpEmToDmD0Pip/model.xml
+++ b/tests/angular-distribution-tests/EpEmToDmD0Pip/model.xml
@@ -105,22 +105,32 @@
 			<RecoilSystem RecoilFinalState="2"></RecoilSystem>
 		</Amplitude>
 	</Amplitude>
-	<Amplitude Class="SequentialAmplitude" Name="EpEm_-1_to_D-_0+D2*(2460)+_-1_L_2.0_S_2.0;D2*(2460)+_-1_to_D0_0+pion+_0_L_2.0_S_0.0;">
-		<Amplitude Name="EpEm_-1_to_D-_0+D2*(2460)+_-1_L_2.0_S_2.0;" Class="HelicityDecay">
-			<DecayParticle Name="EpEm" Helicity="-1"></DecayParticle>
-			<DecayProducts>
-				<Particle Name="D2*(2460)+" FinalState="3 4" Helicity="-1.0"></Particle>
-				<Particle Name="D-" FinalState="2" Helicity="0"></Particle>
-			</DecayProducts>
-		</Amplitude>
-		<Amplitude Name="D2*(2460)+_-1_to_D0_0+pion+_0_L_2.0_S_0.0;" Class="HelicityDecay">
-			<DecayParticle Name="D2*(2460)+" Helicity="-1.0"></DecayParticle>
-			<DecayProducts>
-				<Particle Name="D0" FinalState="3" Helicity="0"></Particle>
-				<Particle Name="pion+" FinalState="4" Helicity="0"></Particle>
-			</DecayProducts>
-			<RecoilSystem RecoilFinalState="2"></RecoilSystem>
-		</Amplitude>
+	<Amplitude Class="CoefficientAmplitude" Name="CoeffAmp_EpEm_-1_to_D-_0+D2*(2460)+_-1_L_2.0_S_2.0;D2*(2460)+_-1_to_D0_0+pion+_0_L_2.0_S_0.0;">
+		<Parameter Class='Double' Type="Magnitude" Name="Magnitude_dummy">
+			<Value>1.0</Value>
+			<Fix>true</Fix>
+		</Parameter>
+		<Parameter Class='Double' Type="Phase" Name="Phase_dummy">
+			<Value>0.0</Value>
+			<Fix>true</Fix>
+		</Parameter>
 		<PreFactor Real="-1" Imaginary="0.0"></PreFactor>
+		<Amplitude Class="SequentialAmplitude" Name="EpEm_-1_to_D-_0+D2*(2460)+_-1_L_2.0_S_2.0;D2*(2460)+_-1_to_D0_0+pion+_0_L_2.0_S_0.0;">
+			<Amplitude Name="EpEm_-1_to_D-_0+D2*(2460)+_-1_L_2.0_S_2.0;" Class="HelicityDecay">
+				<DecayParticle Name="EpEm" Helicity="-1"></DecayParticle>
+				<DecayProducts>
+					<Particle Name="D2*(2460)+" FinalState="3 4" Helicity="-1.0"></Particle>
+					<Particle Name="D-" FinalState="2" Helicity="0"></Particle>
+				</DecayProducts>
+			</Amplitude>
+			<Amplitude Name="D2*(2460)+_-1_to_D0_0+pion+_0_L_2.0_S_0.0;" Class="HelicityDecay">
+				<DecayParticle Name="D2*(2460)+" Helicity="-1.0"></DecayParticle>
+				<DecayProducts>
+					<Particle Name="D0" FinalState="3" Helicity="0"></Particle>
+					<Particle Name="pion+" FinalState="4" Helicity="0"></Particle>
+				</DecayProducts>
+				<RecoilSystem RecoilFinalState="2"></RecoilSystem>
+			</Amplitude>
+		</Amplitude>
 	</Amplitude>
 </Intensity>


### PR DESCRIPTION
Now it is possible to easily create ComPWA compatible data using python.
This means ComPWA Particle, Event and DataPoint structures can now be
created.
Furthermore the HelicityKinematics `convert()` method is now available
in the python UI.