### PR TITLE
feat: clean up requirements for conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ htmlcov/
 pycompwa.egg-info
 
 # Python virtual environments
-venv/
+*venv/
 
 # Build files
 _skbuild/

--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,12 @@ MANIFEST
 # Python temporary files
 *.pyc
 .coverage
+.coverage.*
 .eggs
 .ipynb_checkpoints
 .pytest_cache/
 __pycache__
+htmlcov/
 pycompwa.egg-info
 
 # Python virtual environments

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,26 +10,10 @@ project( pycompwa.ui
 cmake_minimum_required (VERSION 3.4 FATAL_ERROR)
 
 set(DEFAULT_BUILD_TYPE "Release")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Need to add this to the top level CMakeLists.txt
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/ComPWA/cmake/Modules/")
-
-# Find python3
-# unfortunately there is a change in the interface of CMake at version 12
-# in which the PythonInterp gets deprecated and FindPython3 should be used
-# BUT actually the cmake 3.12 version FindPython3 is buggy and cannot find
-# python venvs. So the threshold is actually put to 3.13
-set(Python3_FOUND FALSE)
-if (${CMAKE_MAJOR_VERSION} EQUAL 3 AND ${CMAKE_MINOR_VERSION} LESS 13)
-  find_package(PythonInterp REQUIRED)
-  if(${PYTHONINTERP_FOUND} AND ${PYTHON_VERSION_MAJOR} GREATER 2)
-    set(Python3_FOUND TRUE)
-    set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
-  endif()
-else()
-  set(CMAKE_FIND_FRAMEWORK NEVER)
-  find_package(Python3 REQUIRED COMPONENTS Interpreter)
-endif()
 
 # # Configure RPATH
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/PyComPWA.cpp
+++ b/PyComPWA.cpp
@@ -25,6 +25,7 @@
 #include "Data/Root/RootGenerator.hpp"
 #include "Estimator/MinLogLH/MinLogLH.hpp"
 #include "Optimizer/Minuit2/MinuitIF.hpp"
+#include "Optimizer/Minuit2/MinuitResult.hpp"
 
 #include "Core/FunctionTree/FunctionTreeIntensity.hpp"
 #include "Physics/BuilderXML.hpp"
@@ -437,14 +438,14 @@ PYBIND11_MODULE(ui, m) {
           "fit_duration_in_seconds",
           [](const ComPWA::FitResult &x) { return x.FitDuration.count(); })
       .def_readonly("covariance_matrix", &ComPWA::FitResult::CovarianceMatrix)
-      .def("write",
-           [](const ComPWA::Optimizer::Minuit2::MinuitResult &r,
-              std::string file) {
-             std::ofstream ofs(file);
-             boost::archive::xml_oarchive oa(ofs);
-             oa << BOOST_SERIALIZATION_NVP(r);
-           },
-           py::arg("file"));
+      .def("write", &ComPWA::FitResult::write,
+           "Write fit result to an xml file.", py::arg("filename"));
+
+  m.def("load", &ComPWA::Optimizer::Minuit2::load,
+        "Load a Minuit2 fit result from a file.", py::arg("filename"));
+
+  m.def("load", &ComPWA::load, "Load a fit result from a file.",
+        py::arg("filename"));
 
   py::class_<ComPWA::Optimizer::Minuit2::MinuitResult, ComPWA::FitResult>(
       m, "MinuitResult")
@@ -452,7 +453,9 @@ PYBIND11_MODULE(ui, m) {
            [](const ComPWA::Optimizer::Minuit2::MinuitResult &Result) {
              LOG(INFO) << Result;
            },
-           "Print fit result to the logging system.");
+           "Print fit result to the logging system.")
+      .def("write", &ComPWA::Optimizer::Minuit2::MinuitResult::write,
+           "Write Minuit2 fit result to an xml file.", py::arg("filename"));
 
   m.def("initializeWithFitResult", &ComPWA::initializeWithFitResult,
         "Initializes an Intensity with the parameters of a FitResult.",

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,7 +4,39 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  # everything above 75% will be good (green)
+  range: "75...100"
+
+  status:
+    project:
+      default:
+        # basic
+        target: 75% # can't go below 75%
+        threshold: 3% # allow drops by 3%
+        base: auto 
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+    patch:
+      default:
+        # basic
+        target: 0
+        threshold: 0
+        base: auto 
+        # advanced
+        branches: null
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: error
+        only_pulls: false
+        flags: null
+        paths: null
+    changes: no
 
 parsers:
   gcov:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,9 +1,5 @@
-nbconvert>=5.4.1
-ipython>=7.5.0
-numpy>=1.17.2
-progress>=1.5
-matplotlib>=3.1.1
-xmltodict>=0.12.0
-uproot>=3.10.6
-Sphinx>=2.2.0
-sphinx_rtd_theme>=0.4.3
+jupyter
+nbconvert
+sphinx
+sphinx_rtd_theme
+uproot

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -122,7 +122,7 @@ html_theme_options = {
     'display_version': True,
     'prev_next_buttons_location': 'bottom',
     'style_external_links': False,
-    'vcs_pageview_mode': 'display_github',
+    # 'vcs_pageview_mode': 'display_github',
     # Toc options
     'collapse_navigation': True,
     'sticky_navigation': True,
@@ -141,11 +141,6 @@ html_context = {
     'github_repo': 'pycompwa',
     'github_version': 'master/doc/source/'
 }
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -11,32 +11,29 @@ Developer mode
 --------------
 
 If you want to develop new functionality for pycompwa, installing pycompwa as a
-Conda package will not suffice: you will have to **build from source**. In this
-'developer mode', you still work in a Conda environment (see :ref:`Installation
-<Installation>`), but now you install the pycompwa package from the cloned
-repository using `conda-develop
+pip or Conda package will not suffice: you will have to **build from source**,
+so that you can continuously implement updates. In this 'developer mode', you
+still work in a Conda environment (see :ref:`Installation <Installation>`,
+especially for the `Conda-Forge <https://conda-forge.org/>`__ instructions),
+but now you install the pycompwa package from the cloned repository using
+`conda-develop
 <https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`__,
 so that any changes you make in the source code immediately have effect.
 
-First, create a new Conda environment for pycompwa with the necessary packages:
-
-.. code-block:: shell
-
-  conda create --name compwa python jupyter pytest
-
-Now, clone the pycompwa repository recursively to some suitable folder (you can
-omit the ``<PYCOMPWA_SOURCE_PATH>``):
+First, clone the pycompwa repository recursively to some suitable folder (you
+can omit the ``<PYCOMPWA_SOURCE_PATH>``):
 
 .. code-block:: shell
 
   git clone --recurse-submodules git@github.com:ComPWA/pycompwa.git <PYCOMPWA_SOURCE_PATH>
 
-Then, navigate into the cloned repository under ``<PYCOMPWA_SOURCE_PATH>`` and
-install the required Python packages:
+Now, go into the cloned repository, create a new Conda environment for
+pycompwa with the necessary packages installed, and activate it:
 
 .. code-block:: shell
 
-  pip install -r requirements.txt
+  conda create -n compwa --file requirements.txt
+  conda activate compwa
 
 You can now build the pycompwa package from source:
 
@@ -45,13 +42,13 @@ You can now build the pycompwa package from source:
   mkdir -p build
   cd build
   cmake ..
-  make -j4
+  cmake --build . -- -j4  # adjust 4 to your number of cores
 
 You will then need to set some symbolic links to the Python module of pycompwa:
 
 .. code-block:: shell
 
-  cd pycompwa
+  cd ../pycompwa
   ln -s ../build/ui.*.so .
   ln -s ../ComPWA/Physics/particle_list.xml .
 
@@ -60,10 +57,33 @@ Python interpreter understand the ``import pycompwa`` command. You do this with:
 
 .. code-block:: shell
 
-  conda develop <PATH_TO_pycompwa>
+  conda develop <PYCOMPWA_SOURCE_PATH>
 
-where ``<PATH_TO_pycompwa>`` refers to the absolute or relative path of the
+where ``<PYCOMPWA_SOURCE_PATH>`` refers to the absolute or relative path of the
 cloned pycompwa repository.
+
+Python developer tools
+^^^^^^^^^^^^^^^^^^^^^^
+
+For contributing to pycompwa, we recommend you also install the packages listed
+under `requirements_dev.txt
+<https://github.com/ComPWA/pycompwa/blob/master/requirements_dev.txt>`__. In
+the Conda environment you created for pycompwa:
+
+.. code-block:: shell
+
+  conda install --file requirements_dev.txt
+
+Now you can for instance test the coverage of the unit tests:
+
+.. code-block:: shell
+
+  cd tests
+  pytest --durations=0 --cov-config=.coveragerc --cov=pycompwa --cov-report html -m "not slow"
+
+Now you can find a nice graphical overview of which parts of the code are not
+covered by the tests by opening ``htmlcov/index.html``!
+
 
 How to contribute through Git
 -----------------------------
@@ -239,7 +259,7 @@ the documentation in sync with the code is crucial, and is a lot of work.
 
 The documentation is built with sphinx using the "read the docs" theme. For the
 python code/modules ``sphinx-apidoc`` is used. The comment style is following
-the ``pep8`` conventions.
+the ``doc8`` conventions.
 
 You can build the documentation locally as follows. In your Conda environment,
 navigate to the pycompwa repository, then do:
@@ -247,7 +267,7 @@ navigate to the pycompwa repository, then do:
 .. code-block:: shell
 
   cd doc
-  pip install -r requirements.txt
+  conda install --file requirements.txt
   make html
 
 Now, open the file ``doc/source/_build/html/index.html``.

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -7,15 +7,31 @@
 Installation
 ============
 
-It is best to install the pycompwa framework within a virtual environment, so that all dependencies of pycompwa are contained within there. We recommend to use `Anaconda <https://www.anaconda.com/distribution/>`__.
+It is best to install the pycompwa framework within a virtual environment, so
+that all dependencies of pycompwa are contained within there. We recommend to
+use `Anaconda <https://www.anaconda.com/distribution/>`__ in combination with
+`Conda-Forge <https://conda-forge.org/>`__.
 
-After you have `installed Anaconda <https://docs.anaconda.com/anaconda/install/>`__, create a new environment with the latest version of ``python``, ``pip`` and ``jupyter`` activated:
+After you have `installed Anaconda
+<https://docs.anaconda.com/anaconda/install/>`__, set Conda-Forge as the
+default channel as follows:
 
 .. code-block:: shell
 
-  conda create --name compwa python jupyter
+  conda config --add channels conda-forge
+  conda config --set channel_priority strict
 
-Here, we call the environment ``compwa``, but you can give it any name. Now, go into this environment with ``conda activate compwa``, so we can install pycompwa there:
+Now, create a new environment with `all required dependencies
+<https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`__
+installed:
+
+.. code-block:: shell
+
+  conda create -n compwa --file requirements.txt
+
+Here, we call the environment ``compwa``, but you can give it any name. Now, go
+into this environment with ``conda activate compwa``, so we can install
+pycompwa there:
 
 .. code-block:: shell
 
@@ -24,11 +40,15 @@ Here, we call the environment ``compwa``, but you can give it any name. Now, go 
 
 Note that ``scikit-build`` has to be installed first.
 
-That's it! You can now go through the :ref:`Quickstart Example <example_quickstart>` to learn how to use pycompwa.
+That's it! You can now go through the :ref:`Quickstart Example
+<example_quickstart>` to learn how to use pycompwa.
 
 .. tip::
 
-    Of course, pycompwa can also be used with `jupyter <https://jupyter.org/>`__. You can install jupyter in your virtual Conda environment via ``conda install jupyter``. Then, just navigate to the jupyter examples  ``examples/jupyter`` and run ``jupyter notebook``.
+    Of course, pycompwa can also be used with `jupyter
+    <https://jupyter.org/>`__. You can install jupyter in your virtual Conda
+    environment via ``conda install jupyter``. Then, just navigate to the
+    jupyter examples  ``examples/jupyter`` and run ``jupyter notebook``.
 
 Prerequisites
 -------------
@@ -43,13 +63,18 @@ ComPWA and the pycompwa interface have the following dependencies:
   * Compiler: ``gcc`` or ``clang``
   * `Boost <https://www.boost.org/>`__
   * optional libraries: |br|
-    `ROOT <https://root.cern.ch/downloading-root>`__ and/or `Minuit <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`__,
+    `ROOT <https://root.cern.ch/downloading-root>`__ and/or `Minuit
+    <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`__,
     `Geneva <https://www.gemfony.eu/>`__, and
     `GSL <https://www.gnu.org/software/gsl/>`__
 
-More information on how to install these can be found by following the links.
+* The Python requirements listed `here
+  <https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`__
 
 Installation from source
 ------------------------
 
-If you are a pycompwa developer, you will have to build the framework from source instead of using the pycompwa release that is distributed through ``conda``. See :ref:`Developer Mode <DeveloperMode>` for the installation instructions.
+If you are a pycompwa developer, you will have to build the framework from
+source instead of using the pycompwa release that is distributed through
+``conda``. See :ref:`Developer Mode <DeveloperMode>` for the installation
+instructions.

--- a/doc/source/python-ui.rst
+++ b/doc/source/python-ui.rst
@@ -3,13 +3,13 @@
 Python UI
 ---------
 
-The Python User Interface is a python module named :code:`ui`, built with 
+The Python User Interface is a python module named :code:`ui`, built with
 `pybind11 <https://pybind11.readthedocs.io/en/stable/index.html>`_.
-It is the recommended way to use ComPWA, since the user benefits from the python
-ease of use.
+It is the recommended way to use ComPWA, since the user benefits from the
+python ease of use.
 
 .. note::
-   Because the Python UI calls the c++ code in the background, you do not have 
+   Because the Python UI calls the c++ code in the background, you do not have
    to worry about speed. It runs just as fast ;)
 
 Since the Python UI just binds to the c++ user interface code, there is a strong
@@ -20,8 +20,8 @@ correlation between the two. It's useful to read more about the
    On how to use the Python UI, also refer to the
    :ref:`examples section<examples>`.
 
-The Python UI enables you to perform all of the tasks needed for your partial 
-wave analysis: 
+The Python UI enables you to perform all of the tasks needed for your partial
+wave analysis:
 
 .. _dataio:
 
@@ -29,7 +29,7 @@ Read and Write Data Samples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For python users it is recommended to first load the data into a common format
-via numpy or pandas and then construct :class:`.Event` s and 
+via numpy or pandas and then construct :class:`.Event` s and
 :class:`.Particle` s.
 
 .. autoclass:: pycompwa.ui.Event
@@ -45,10 +45,12 @@ via numpy or pandas and then construct :class:`.Event` s and
 The procedure is explained :ref:`here<example_datainput>` in more detail.
 
 Alternatively, the reading and writing of ROOT files is supported via the
-:class:`.RootDataIO` class.
+:func:`.read_root_data` and :func:`.write_root_data` functions.
 
-.. autoclass:: pycompwa.ui.RootDataIO
-   :members:
+.. autofunction:: pycompwa.ui.read_root_data
+   :noindex:
+
+.. autofunction:: pycompwa.ui.write_root_data
    :noindex:
 
 .. tip::
@@ -56,15 +58,15 @@ Alternatively, the reading and writing of ROOT files is supported via the
    previous method via Events and Particles is more flexible and recommended.
 
 For the reading of data/events a predefined tree structure is assumed. The name
-of the tree inside the file and the number of events to process can be by 
-adjusted in the constructor. By default the tree name is *"data"* and all events
-are processed. Inside the tree a :cpp:class:`TClonesArray` with the name 
-*"Particles"* is expected. This :cpp:class:`TClonesArray` should contain 
+of the tree inside the file and the number of events to process can be by
+adjusted in the constructor. By default the tree name is *"data"* and all
+events are processed. Inside the tree a :cpp:class:`TClonesArray` with the name
+*"Particles"* is expected. This :cpp:class:`TClonesArray` should contain
 :cpp:class:`TParticle`'s, the final state particles.
 
 The order of the particles inside the :cpp:class:`TClonesArray` can easily be
-adjusted in the Kinematics section of your model xml file. Just use the 
-``PositionIndex`` attribute to specify the position inside the 
+adjusted in the Kinematics section of your model xml file. Just use the
+``PositionIndex`` attribute to specify the position inside the
 :cpp:class:`TClonesArray`.
 
 Generate Data Samples
@@ -90,7 +92,7 @@ data samples:
    :noindex:
 
   To initialize such a PhaseSpaceGenerator the Kinematics information of the
-  reaction is required. This can be extracted from the 
+  reaction is required. This can be extracted from the
   :class:`.HelicityKinematics`.
   Read :ref:`below<create-kin-and-intens>` on how to create such a Kinematics
   instance.
@@ -104,12 +106,12 @@ data samples:
   *  .. autoclass:: pycompwa.ui.RootUniformRealGenerator
         :special-members: __init__
         :noindex:
-  
+
 * Generating data samples based on a Intensity
 
   The usage is similar to the :ref:`phase space generation<generatephsp>`. Now
   the Intensity has to be given as an additional argument. A hit-or-miss based
-  sampling will be performed. 
+  sampling will be performed.
 
   .. autofunction:: pycompwa.ui.generate
      :noindex:
@@ -123,14 +125,14 @@ data samples:
      The current implementation is simple and uniformly generates events in the
      phase space domain. Depending on the shape of your Intensity, this can be
      quite computation intensive. However, ideally you would only run this once
-     for a specific reaction. 
+     for a specific reaction.
 
 .. _loadparticles:
 
 Loading and Defining Particles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Particles can loaded and stored inside a :class:`.PartList`. 
+Particles can loaded and stored inside a :class:`.PartList`.
 
 .. autofunction:: pycompwa.ui.read_particles
    :noindex:
@@ -148,30 +150,32 @@ Create a Kinematics and Intensity Instance from a Description
 
 As a prerequisite a :class:`.PartList` has to be already loaded.
 
-A HelicityKinematics instance can be created with 
+A HelicityKinematics instance can be created with
 :func:`.create_helicity_kinematics`
 
 .. autofunction:: pycompwa.ui.create_helicity_kinematics
    :noindex:
 
-Analogous a Intensity instance can be created with :func:`.create_intensity`
+Analogous a Intensity instance can be created with
+:func:`.IntensityBuilderXML.create_intensity`
 
-.. autofunction:: pycompwa.ui.create_intensity
+.. autofunction:: pycompwa.ui.IntensityBuilderXML.create_intensity
    :noindex:
 
 Here the order of execution is important and can be slightly confusing.
 In order to fit an Intensity to a data sample, the Intensity has to be
 normalized (when using an unbinned log likelihood estimator). Because the
 normalization is performed by MC integration, a phase space sample is needed.
-This however requires a Kinematics instance. Therefore the order of execution is:
+This however requires a Kinematics instance. Therefore the order of execution
+is:
 
 1. Create/Load a :class:`.PartList`
 2. Create a Kinematics instance
-3. Create a phase space sample (alternatively: the data can also be 
+3. Create a phase space sample (alternatively: the data can also be
    :ref:`read from file<dataio>`)
 4. Create an Intensity using the phase space sample and the Kinematics instance
 
-   
+
 Fit an Intensity to a Data Sample
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -187,6 +191,6 @@ Load and Initialize a previous Fit Result
 
 Coming soon...
 
-Visualizing of data samples and Intensities can be done via the 
+Visualizing of data samples and Intensities can be done via the
 :mod:`pycompwa.plotting module` documented in the next section.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,5 @@
-scikit-build
-ipython
-numpy
-pandas
-progress
+python=3.7
 matplotlib
+numpy
+progress
 xmltodict
-pytest
-uproot
-scipy
-ipykernel

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,6 @@
+autopep8
+doc8
+pylint
+pytest
+pytest-cov
+scipy

--- a/tests/test_YToD0D0barPi0Pi0.py
+++ b/tests/test_YToD0D0barPi0Pi0.py
@@ -2,6 +2,7 @@
     Y -> D*0 D*0bar -> D0 D0bar pi0 pi0
 """
 import logging
+import pytest
 
 from pycompwa.expertsystem.amplitude.canonicaldecay import (
     CanonicalAmplitudeGeneratorXML
@@ -49,7 +50,7 @@ def test_script_simple():
 
     graph_node_setting_pairs = tbd_manager.prepare_graphs()
 
-    (solutions, violated_rules) = tbd_manager.find_solutions(
+    solutions, _ = tbd_manager.find_solutions(
         graph_node_setting_pairs)
 
     print("found " + str(len(solutions)) + " solutions!")
@@ -77,7 +78,7 @@ def test_script_simple():
     tbd_manager.number_of_threads = 2
 
     graph_node_setting_pairs = tbd_manager.prepare_graphs()
-    (solutions, violated_rules) = tbd_manager.find_solutions(
+    solutions, _ = tbd_manager.find_solutions(
         graph_node_setting_pairs)
     print("found " + str(len(solutions)) + " solutions!")
 
@@ -88,6 +89,7 @@ def test_script_simple():
             len(canonical_xml_generator.get_fit_parameters()))
 
 
+@pytest.mark.slow
 def test_script_full():
     # initialize the graph edges (initial and final state)
     initial_state = [("Y", [-1, 1])]
@@ -115,7 +117,7 @@ def test_script_full():
 
     graph_node_setting_pairs = tbd_manager.prepare_graphs()
 
-    (solutions, violated_rules) = tbd_manager.find_solutions(
+    solutions, _ = tbd_manager.find_solutions(
         graph_node_setting_pairs)
 
     print("found " + str(len(solutions)) + " solutions!")
@@ -144,7 +146,7 @@ def test_script_full():
     tbd_manager.number_of_threads = 2
 
     graph_node_setting_pairs = tbd_manager.prepare_graphs()
-    (solutions, violated_rules) = tbd_manager.find_solutions(
+    solutions, _ = tbd_manager.find_solutions(
         graph_node_setting_pairs)
     print("found " + str(len(solutions)) + " solutions!")
 


### PR DESCRIPTION
* We now request the user to use at most Python 3.7 (see [this issue](https://github.com/pybind/pybind11/pull/1784#issuecomment-590822668) on pybind).
* The `requirements.txt` files have been split up into the essential, those for development and those for documentation
* Versions have been remove if not necessary, because Conda takes care of that.