### PR TITLE
docs: improve API references

### DIFF
--- a/doc/source/api/pycompwa.ui.rst
+++ b/doc/source/api/pycompwa.ui.rst
@@ -2,8 +2,8 @@ ui
 ==
 
 This package defines the interface to the computational backend
-`ComPWA <https://compwa.github.io/ComPWA/>`__. These bindings have been defined
-with `pybind11 <https://pybind11.readthedocs.io/>`__.
+`ComPWA <https://compwa.github.io/ComPWA/>`_. These bindings have been defined
+with `pybind11 <https://pybind11.readthedocs.io/>`_.
 
 Module contents
 ---------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,6 +106,9 @@ extensions = [
     'sphinx_copybutton',
 ]
 
+# Cross-referencing configuration
+default_role = 'py:obj'
+primary_domain = 'py'
 # Settings for autosectionlabel
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -100,6 +100,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.githubpages',
     'sphinx.ext.ifconfig',
+    'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
@@ -109,6 +110,16 @@ extensions = [
 # Cross-referencing configuration
 default_role = 'py:obj'
 primary_domain = 'py'
+
+# Settings for intersphinx
+intersphinx_mapping = {
+    'matplotlib': ('https://matplotlib.org/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'python': ('https://docs.python.org/3', None),
+    'pybind11': ('https://pybind11.readthedocs.io/en/stable', None),
+}
+
 # Settings for autosectionlabel
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 1

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -110,6 +110,13 @@ extensions = [
 # Cross-referencing configuration
 default_role = 'py:obj'
 primary_domain = 'py'
+nitpicky = True  # warn if cross-references are missing
+nitpick_ignore = [
+    ('py:class', 'function'),
+    ('py:class', 'pycompwa.expertsystem.solvers.constraint.Constraint'),
+    ('py:class', 'pycompwa.expertsystem.state.propagation.GraphElementTypes'),
+    ('py:class', 'pybind11_builtins.pybind11_object'),
+]
 
 # Settings for intersphinx
 intersphinx_mapping = {

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -5,9 +5,9 @@
 How to contribute
 =================
 
-.. _DeveloperMode:
+.. _Developer Mode:
 
-Developer mode
+Developer Mode
 --------------
 
 If you want to develop new functionality for pycompwa, installing pycompwa as a
@@ -292,6 +292,7 @@ Try and follow his advice, and keep in mind the 'boy scout rule'::
 
 For the python code we follow the `pep8 standard
 <https://www.python.org/dev/peps/pep-0008/>`_. Available automatic source code
+highlighters and formatters are ``flake8`` and ``autopep8``.
 
 Documentation
 -------------

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -13,11 +13,10 @@ Developer mode
 If you want to develop new functionality for pycompwa, installing pycompwa as a
 pip or Conda package will not suffice: you will have to **build from source**,
 so that you can continuously implement updates. In this 'developer mode', you
-still work in a Conda environment (see :ref:`installation:Installation`,
-especially for the `Conda-Forge <https://conda-forge.org/>`__ instructions),
-but now you install the pycompwa package from the cloned repository using
-`conda-develop
-<https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`__,
+still work in a Conda environment (see :doc:`installation`, especially for the
+`Conda-Forge <https://conda-forge.org/>`_ instructions), but now you install
+the :mod:`pycompwa` package from the cloned repository using `conda-develop
+<https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`_,
 so that any changes you make in the source code immediately have effect.
 
 First, clone the pycompwa repository recursively to some suitable folder (you
@@ -69,14 +68,14 @@ Python developer tools
 
 For contributing to pycompwa, we recommend you also install the packages listed
 under `requirements_dev.txt
-<https://github.com/ComPWA/pycompwa/blob/master/requirements_dev.txt>`__. In
+<https://github.com/ComPWA/pycompwa/blob/master/requirements_dev.txt>`_. In
 the Conda environment you created for pycompwa:
 
 .. code-block:: shell
 
   conda install --file requirements_dev.txt
 
-An important tool there is `pre-commit <https://pre-commit.com/>`__. This will
+An important tool there is `pre-commit <https://pre-commit.com/>`_. This will
 run certain tests locally when you make a Git commit. To activate, run the
 following after cloning:
 
@@ -115,20 +114,20 @@ Jupyter notebooks aren't the most friendly with regard to Version Control
 Systems like Git because in the back-end, a notebook is a JSON file that
 changes for instances when you run a cell. There is no simple solution for this
 other than to clean the cell output upon saving. You can automatize this with
-`nbstripout <https://github.com/kynan/nbstripout>`__ if you have activated
+`nbstripout <https://github.com/kynan/nbstripout>`_ if you have activated
 ``pre-commit`` (see :ref:`python-dev-tools`).
 
 Jupyter offers several other useful extensions that can be activate `like this
-<https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/install.html#enabling-disabling-extensions>`__
+<https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/install.html#enabling-disabling-extensions>`_
 If you want to contribute to the example notebooks, make sure to check out the
 following extensions:
 
 * `jupyter-autopep8
-  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/code_prettify/README_autopep8.html>`__
+  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/code_prettify/README_autopep8.html>`_
 * `ruler
-  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/ruler/readme.html>`__
+  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/ruler/readme.html>`_
 * `sphellchecker
-  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/spellchecker/README.html>`__
+  <https://jupyter-contrib-nbextensions.readthedocs.io/en/latest/nbextensions/spellchecker/README.html>`_
 
 
 How to contribute through Git
@@ -141,10 +140,10 @@ How to contribute through Git
 
 If you are new to git, maybe you should read some documentation first, such as
 the
-`Git Manual <https://git-scm.com/docs/user-manual.html>`__,
-`Tutorial <http://rogerdudler.github.io/git-guide/>`__, a
-`CheatSheet <https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf>`__.
-The `Git Pro <https://git-scm.com/book/en/v2>`__ book particularly serves as a
+`Git Manual <https://git-scm.com/docs/user-manual.html>`_,
+`Tutorial <http://rogerdudler.github.io/git-guide/>`_, a
+`CheatSheet <https://services.github.com/on-demand/downloads/github-git-cheat-sheet.pdf>`_.
+The `Git Pro <https://git-scm.com/book/en/v2>`_ book particularly serves as a
 great, free overview that is a nice read for both beginners and more
 experienced users.
 
@@ -155,7 +154,7 @@ contribute:
 2. Get a local copy of repository: |br|
    ``git clone git@github.com:YOURACCOUNT/pycompwa.git`` |br|
    (this uses the SSH protocol, so you need to `set your SSH keys
-   <https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification>`__
+   <https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification>`_
    first)
 3. Add the main repository as a second remote called ``upstream``: |br|
    ``git remote add upstream git@github.com:ComPWA/pycompwa.git``
@@ -171,7 +170,7 @@ contribute:
 
 You repeat the following steps until your contribution is finished. Only then
 can your contributions be added main repository through a `pull request
-<https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests>`__
+<https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests>`_
 (PR).
 
 * ... edit some files ...
@@ -195,7 +194,7 @@ can your contributions be added main repository through a `pull request
     Otherwise repeat these steps until you're done (you can abort the whole
     rebase process via ``git rebase --abort``):
 
-    + Review the conflicts (`VS Code <https://code.visualstudio.com/>`__ is a
+    + Review the conflicts (`VS Code <https://code.visualstudio.com/>`_ is a
       great tool for this)
     + Mark them as resolved ``git add <filename>``
     + Continue the rebase ``git rebase --continue``
@@ -233,15 +232,15 @@ Commit conventions
 * In the master branch, it should be possible to compile and test the framework
   **in each commit**. In your own topic branches, it is recommended to commit
   frequently (WIP keyword), but `squash those commits
-  <https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History>`__
+  <https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History>`_
   to compilable commits upon submitting a merge request.
 * Please use `conventional commit messages
-  <https://www.conventionalcommits.org/>`__: start the commit subject line with
+  <https://www.conventionalcommits.org/>`_: start the commit subject line with
   a semantic keyword (see e.g. `Angular
-  <https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type>`__ or
+  <https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type>`_ or
   `these examples
-  <https://seesparkbox.com/foundry/semantic_commit_messages>`__,
-  followed by `a column <https://git-scm.com/docs/git-interpret-trailers>`__,
+  <https://seesparkbox.com/foundry/semantic_commit_messages>`_,
+  followed by `a column <https://git-scm.com/docs/git-interpret-trailers>`_,
   then the message. The subject line should be in imperative mood—just imagine
   the commit to give a command to the code framework. So for instance:
   ``feat: add coverage report tools`` or ``fix: remove ...``. The message
@@ -254,7 +253,7 @@ Commit conventions
 Reporting Issues
 ----------------
 Use the `pycompwa github issues page
-<https://github.com/ComPWA/pycompwa/issues>`__ to:
+<https://github.com/ComPWA/pycompwa/issues>`_ to:
 
 * report problems/issues
 * file a feature request
@@ -270,14 +269,14 @@ Continuous Integration (CI)
 ---------------------------
 The master branch is automatically build using TravisCI. Probably it is
 interesting to check out the `log file
-<https://travis-ci.com/ComPWA/pycompwa>`__ and the projects TravisCI
+<https://travis-ci.com/ComPWA/pycompwa>`_ and the projects TravisCI
 configuration file `travisCI.yml
-<https://github.com/ComPWA/pycompwa/blob/master/.travis.yml>`__.
+<https://github.com/ComPWA/pycompwa/blob/master/.travis.yml>`_.
 
 A code coverage report is generated for each pull request. Try to keep coverage
 high by writing new tests if coverage decreases. You can see an overview
-pycompwa's coverage `here <https://codecov.io/gh/ComPWA/pycompwa>`__. Under
-`files <https://codecov.io/gh/ComPWA/pycompwa/tree/master/pycompwa>`__ you have
+pycompwa's coverage `here <https://codecov.io/gh/ComPWA/pycompwa>`_. Under
+`files <https://codecov.io/gh/ComPWA/pycompwa/tree/master/pycompwa>`_ you have
 a detailed overview of coverage per module, and you can investigate coverage
 all the way down to the source code.
 
@@ -292,8 +291,7 @@ Try and follow his advice, and keep in mind the 'boy scout rule'::
   "Leave behind the code cleaner, then you found it"
 
 For the python code we follow the `pep8 standard
-<https://www.python.org/dev/peps/pep-0008/>`__. Available automatic source code
-highlighters and formatters are `flake8` and `autopep8`.
+<https://www.python.org/dev/peps/pep-0008/>`_. Available automatic source code
 
 Documentation
 -------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@ Welcome to the pycompwa website!
 
 The ``pycompwa`` package is a collection of python modules that interface and
 extend the "Common Partial-Wave-Analysis Framework"
-(`ComPWA <https://github.com/ComPWA/ComPWA>`__).
+(`ComPWA <https://github.com/ComPWA/ComPWA>`_).
 These pages provide information about the installation, how-tos to get things
 running, information on the design, as well as documentation of the ongoing
 development.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,7 +1,7 @@
 Welcome to the pycompwa website!
 ================================
 
-The ``pycompwa`` package is a collection of python modules that interface and
+The :mod:`pycompwa` package is a collection of python modules that interface and
 extend the "Common Partial-Wave-Analysis Framework"
 (`ComPWA <https://github.com/ComPWA/ComPWA>`_).
 These pages provide information about the installation, how-tos to get things

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -7,11 +7,11 @@ Installation
 
 It is best to install the pycompwa framework within a virtual environment, so
 that all dependencies of pycompwa are contained within there. We recommend to
-use `Anaconda <https://www.anaconda.com/distribution/>`__ in combination with
-`Conda-Forge <https://conda-forge.org/>`__.
+use `Anaconda <https://www.anaconda.com/distribution/>`_ in combination with
+`Conda-Forge <https://conda-forge.org/>`_.
 
 After you have `installed Anaconda
-<https://docs.anaconda.com/anaconda/install/>`__, set Conda-Forge as the
+<https://docs.anaconda.com/anaconda/install/>`_, set Conda-Forge as the
 default channel as follows:
 
 .. code-block:: shell
@@ -20,7 +20,7 @@ default channel as follows:
   conda config --set channel_priority strict
 
 Now, create a new environment with `all required dependencies
-<https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`__
+<https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`_
 installed:
 
 .. code-block:: shell
@@ -56,19 +56,19 @@ ComPWA and the pycompwa interface have the following dependencies:
 
 * ``scikit-build`` (a python package) |br|
   Install via ``pip install scikit-build``
-* requirements of `ComPWA <https://github.com/ComPWA/ComPWA#prerequisites>`__:
+* requirements of `ComPWA <https://github.com/ComPWA/ComPWA#prerequisites>`_:
 
-  * Build tool: `cmake <https://cmake.org/>`__
+  * Build tool: `cmake <https://cmake.org/>`_
   * Compiler: ``gcc`` or ``clang``
-  * `Boost <https://www.boost.org/>`__
+  * `Boost <https://www.boost.org/>`_
   * optional libraries: |br|
-    `ROOT <https://root.cern.ch/downloading-root>`__ and/or `Minuit
-    <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`__,
-    `Geneva <https://www.gemfony.eu/>`__, and
-    `GSL <https://www.gnu.org/software/gsl/>`__
+    `ROOT <https://root.cern.ch/downloading-root>`_ and/or `Minuit
+    <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`_,
+    `Geneva <https://www.gemfony.eu/>`_, and
+    `GSL <https://www.gnu.org/software/gsl/>`_
 
 * The Python requirements listed `here
-  <https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`__
+  <https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`_
 
 Installation from source
 ------------------------

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -74,6 +74,6 @@ Installation from source
 ------------------------
 
 If you are a pycompwa developer, you will have to build the framework from
-source instead of using the pycompwa release that is distributed through
-``conda``. See :ref:`Developer Mode <DeveloperMode>` for the installation
-instructions.
+source instead of using the :mod:`pycompwa` release that is distributed through
+`Conda <https://docs.conda.io/>`_. See :ref:`Developer Mode` for the
+installation instructions.

--- a/doc/source/modules.rst
+++ b/doc/source/modules.rst
@@ -1,8 +1,8 @@
 Main modules
 ============
 
-This pages explains the aim and usage of the main modules of ``pycompwa``. For
-the technical details see the :ref:`modindex`. You can also have a look at the
+This pages explains the aim and usage of the main modules of :mod:`pycompwa`.
+For the technical details see the :ref:`modindex`. You can also have a look at the
 examples under :doc:`usage`.
 
 .. include:: modules/expertsystem.inc

--- a/doc/source/modules/ui.inc
+++ b/doc/source/modules/ui.inc
@@ -1,9 +1,7 @@
-.. _python-ui:
-
 Python UI
 ---------
 
-The Python User Interface is a python module named :py:mod:`ui <pycompwa.ui>`,
+The Python User Interface is a python module named :mod:`~pycompwa.ui`,
 built with `pybind11 <https://pybind11.readthedocs.io/en/stable/index.html>`_.
 It is the recommended way to use ComPWA, since the user benefits from the
 python ease of use.
@@ -28,7 +26,7 @@ Read and Write Data Samples
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For Python users, it is recommended to first load the data into a common format
-via numpy or pandas and then construct :class:`Event` classes.
+via numpy or pandas and then construct :class:`~.Event` classes.
 
 .. autoclass:: pycompwa.ui.Event
    :members:
@@ -70,10 +68,10 @@ data samples:
   .. autofunction:: pycompwa.ui.generate_phsp
      :noindex:
 
-  A required argument is a :class:`PhaseSpaceGenerator` instance. There are
-  currently two options: :class:`.EvtGenGenerator` and :class:`.RootGenerator`.
-  Using the :class:`.EvtGenGenerator` is recommended, due to numerical
-  precision reasons.
+  A required argument is a :class:`~.PhaseSpaceEventGenerator` instance. There
+  are currently two options: :class:`~.EvtGenGenerator` and
+  :class:`~.RootGenerator`. Using the :class:`~.EvtGenGenerator` is
+  recommended, due to numerical precision.
 
   .. autoclass:: pycompwa.ui.EvtGenGenerator
    :special-members: __init__
@@ -81,8 +79,8 @@ data samples:
 
   To initialize such a PhaseSpaceGenerator the Kinematics information of the
   reaction is required. This can be extracted from the
-  :class:`.HelicityKinematics`.
-  Read :ref:`below<create-kin-and-intens>` on how to create such a Kinematics
+  :class:`~.HelicityKinematics`.
+  Read :ref:`below <create-kin-and-intens>` on how to create such a Kinematics
   instance.
 
   The second argument for the :func:`.generate_phsp` function is a random
@@ -97,7 +95,7 @@ data samples:
 
 * Generating data samples based on a Intensity
 
-  The usage is similar to the :ref:`phase space generation<generatephsp>`. Now
+  The usage is similar to the :ref:`phase space generation <generatephsp>`. Now
   the Intensity has to be given as an additional argument. A hit-or-miss based
   sampling will be performed.
 
@@ -120,12 +118,12 @@ data samples:
 Loading and Defining Particles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Particles can loaded and stored inside a :class:`.PartList`.
+Particles can loaded and stored inside a ``PartList``.
 
 .. autofunction:: pycompwa.ui.read_particles
    :noindex:
 
-Also particles can be inserted to an existing :class:`.PartList`, overwriting
+Also particles can be inserted to an existing ``PartList``, overwriting
 already existing particles.
 
 .. autofunction:: pycompwa.ui.insert_particles
@@ -136,16 +134,16 @@ already existing particles.
 Create a Kinematics and Intensity Instance from a Description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-As a prerequisite a :class:`.PartList` has to be already loaded.
+As a prerequisite a ``PartList`` has to be already loaded.
 
 A HelicityKinematics instance can be created with
-:func:`.create_helicity_kinematics`
+:func:`~.create_helicity_kinematics`
 
 .. autofunction:: pycompwa.ui.create_helicity_kinematics
    :noindex:
 
 Analogous a Intensity instance can be created with
-:func:`.IntensityBuilderXML.create_intensity`
+:meth:`~.IntensityBuilderXML.create_intensity`:
 
 .. autofunction:: pycompwa.ui.IntensityBuilderXML.create_intensity
    :noindex:
@@ -157,10 +155,10 @@ normalization is performed by MC integration, a phase space sample is needed.
 This however requires a Kinematics instance. Therefore the order of execution
 is:
 
-1. Create/Load a :class:`.PartList`
+1. Create/Load a ``PartList``
 2. Create a Kinematics instance
 3. Create a phase space sample (alternatively: the data can also be
-   :ref:`read from file<dataio>`)
+   :ref:`read from file <dataio>`)
 4. Create an Intensity using the phase space sample and the Kinematics instance
 
 
@@ -180,4 +178,4 @@ Load and Initialize a previous Fit Result
 Coming soon...
 
 Visualizing of data samples and Intensities can be done via the
-:mod:`pycompwa.plotting module` documented in the next section.
+:mod:`~.plotting` module documented in the next section.

--- a/examples/workflow/4_analyze_results.ipynb
+++ b/examples/workflow/4_analyze_results.ipynb
@@ -430,11 +430,19 @@
    ]
   },
   {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
+    "That's it! You can check some of the other :ref:`examples <usage:usage>` to\n",
+    "learn about more detailed features of ComPWA."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's it! You can check some of the other examples to learn about more detailed features of ComPWA.\n",
-    "\n",
     "And, please, feel free to\n",
     "[provide feedback](https://github.com/ComPWA/pycompwa/issues/new)\n",
     "or [contribute](https://compwa.github.io/contribute.html) ;)"

--- a/examples/workflow/4_analyze_results.ipynb
+++ b/examples/workflow/4_analyze_results.ipynb
@@ -73,11 +73,10 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "It is easiest to analyze your data with `pandas.DataFrame\n",
-    "<https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_.\n",
+    "It is easiest to analyze your data with :class:`pandas.DataFrame`.\n",
     "We are mostly interested in the distributions of the kinematic variables, so\n",
-    "we first have to convert the :class:`~.DataSet` instances to a `DataFrame\n",
-    "<https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_:"
+    "we first have to convert the :class:`~.DataSet` instances to a\n",
+    ":class:`~pandas.DataFrame`:"
    ]
   },
   {
@@ -106,12 +105,19 @@
    "metadata": {},
    "source": [
     "We added a weights column here as well, though in this case, all data weights\n",
-    "are unity.\n",
-    "\n",
+    "are unity."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
+   "source": [
     "Also note that we converted the phase space data set. This is because the\n",
     "phase space serves as a uniform space over which to evaluate the intensity.\n",
     "We therefore attribute an intensity as a weight to each entry in the phase\n",
-    "space `DataFrame`:"
+    "space :class:`~pandas.DataFrame`:"
    ]
   },
   {
@@ -132,11 +138,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "Now that we converted our data to\n",
-    "[pandas.DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html),\n",
+    "Now that we converted our data to :class:`pandas.DataFrame`,\n",
     "we can use its full potential! For instance, we can easily bin the\n",
     "distributions into histograms."
    ]
@@ -154,11 +161,11 @@
     "raw_mimetype": "text/restructuredtext"
    },
    "source": [
-    "Currently, the columns of the ``DataFrame`` created above contain final state\n",
-    "IDs. Of course, you would rather see particle names there, but we need to use\n",
-    "unique IDs in case there are identical particle names. To convert the number\n",
-    "IDs to particle names in the eventual plots, we first extract a mapping from\n",
-    "the :class:`~.Kinematics` object:"
+    "Currently, the columns of the :class:`~pandas.DataFrame` created above\n",
+    "contain final state IDs. Of course, you would rather see particle names\n",
+    "there, but we need to use unique IDs in case there are identical particle\n",
+    "names. To convert the number IDs to particle names in the eventual plots, we\n",
+    "first extract a mapping from the :class:`~.Kinematics` object:"
    ]
   },
   {
@@ -179,12 +186,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "Now you can apply the usual\n",
-    "[matplotlib.pyplot](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.html)\n",
-    "tools to plot the distributions."
+    "Now you can apply the usual :mod:`matplotlib.pyplot` tools to plot the\n",
+    "distributions."
    ]
   },
   {
@@ -225,12 +233,15 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
     "Applying a transformation to one of the columns is also easily done for a\n",
-    "`pandas.DataFrame`. For instance, if you are interested in the invariant mass\n",
-    "(and not the **square value** of the invariant mass), simply do:"
+    ":class:`pandas.DataFrame`. For instance, if you are interested in the\n",
+    "invariant mass (and not the **square value** of the invariant mass), simply\n",
+    "use `~numpy.sqrt`:"
    ]
   },
   {
@@ -274,12 +285,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
+   "cell_type": "raw",
+   "metadata": {
+    "raw_mimetype": "text/restructuredtext"
+   },
    "source": [
-    "We now use\n",
-    "[matplotlib.pyplot.hist2d](https://matplotlib.org/api/_as_gen/matplotlib.pyplot.hist2d.html)\n",
-    "to generate the Dalitz plots:"
+    "We now use `~matplotlib.pyplot.hist2d` to generate the Dalitz plots:"
    ]
   },
   {

--- a/pycompwa/__init__.py
+++ b/pycompwa/__init__.py
@@ -2,7 +2,7 @@
 A Python package for Partial Wave Analysis.
 
 ``pycompwa`` is the python interface to `ComPWA
-<https://github.com/ComPWA/ComPWA>`__, the “Common Partial Wave Analysis
+<https://github.com/ComPWA/ComPWA>`_, the “Common Partial Wave Analysis
 framework”. In addition, ``pycompwa`` provides some general tools that are
 useful when doing PWA research with Python.
 """

--- a/pycompwa/__init__.py
+++ b/pycompwa/__init__.py
@@ -1,9 +1,9 @@
 """
 A Python package for Partial Wave Analysis.
 
-``pycompwa`` is the python interface to `ComPWA
+This is the python interface to `ComPWA
 <https://github.com/ComPWA/ComPWA>`_, the “Common Partial Wave Analysis
-framework”. In addition, ``pycompwa`` provides some general tools that are
+framework”. In addition, this module provides some general tools that are
 useful when doing PWA research with Python.
 """
 

--- a/pycompwa/expertsystem/amplitude/helicitydecay.py
+++ b/pycompwa/expertsystem/amplitude/helicitydecay.py
@@ -311,11 +311,11 @@ class HelicityAmplitudeNameGenerator(AbstractAmplitudeNameGenerator):
     def generate_unique_amplitude_name(self, graph, node_id=None):
         '''
         Generates a unique name for the amplitude corresponding to the given
-        :py:class:`StateTransitionGraph`.
+        :class:`.StateTransitionGraph`.
 
         :param node_id: Use this argument to generate a unique name for the
             partial amplitude corresponding to the interaction node of the
-            given :py:class:`StateTransitionGraph`.
+            given :class:`.StateTransitionGraph`.
         '''
         name = ''
         if isinstance(node_id, int):

--- a/pycompwa/expertsystem/state/conservationrules.py
+++ b/pycompwa/expertsystem/state/conservationrules.py
@@ -1,3 +1,6 @@
+''' Functors for quantum number condition checks '''
+
+
 from abc import ABC, abstractmethod
 from functools import reduce
 from copy import deepcopy
@@ -14,9 +17,6 @@ from .particle import (
     QuantumNumberClasses,
     is_boson,
     Spin)
-
-
-''' Functors for quantum number condition checks '''
 
 
 class AbstractConditionFunctor(ABC):
@@ -102,8 +102,11 @@ class DefinedIfOtherQnNotDefinedInOutSeparate(AbstractConditionFunctor):
 
 
 def is_particle_antiparticle_pair(pid1, pid2):
-    # we just check if the pid is opposite in sign
-    # this is a requirement of the pid numbers of course
+    """Check if PID is opposite sign.
+
+    We just check if the pid is opposite in sign, this is a requirement of
+    the pid numbers of course
+    """
     return pid1 == -pid2
 
 
@@ -199,7 +202,7 @@ class ParityConservation(AbstractRule):
             DefinedForInteractionNode()])
 
     def check(self, ingoing_part_qns, outgoing_part_qns, interaction_qns):
-        """ implements :math:`P_{in} = P_{out} \\cdot (-1)^L` """
+        """Implements :math:`P_{in} = P_{out} \\cdot (-1)^L` ."""
         # is this valid for two outgoing particles only?
         parity_label = StateQuantumNumberNames.Parity
         parity_in = reduce(
@@ -225,8 +228,7 @@ class ParityConservationHelicity(AbstractRule):
                              [DefinedForInteractionNode()])
 
     def check(self, ingoing_part_qns, outgoing_part_qns, interaction_qns):
-        """
-        Implements the check
+        """Implements the check.
 
         :math:`A_{-\\lambda_1-\\lambda_2} = P_1 P_2 P_3 (-1)^{S_2+S_3-S_1} A_{\\lambda_1\\lambda_2}`
 
@@ -279,7 +281,7 @@ class CParityConservation(AbstractRule):
                                  [StateQuantumNumberNames.Cparity])])
 
     def check(self, ingoing_part_qns, outgoing_part_qns, interaction_qns):
-        """ implements :math:`C_{in} = C_{out}` """
+        """Implements :math:`C_{in} = C_{out}`."""
         cparity_in = self.get_cparity_multiparticle(
             ingoing_part_qns, interaction_qns)
         if cparity_in is None:
@@ -357,7 +359,7 @@ class GParityConservation(AbstractRule):
                                  [StateQuantumNumberNames.Gparity])])
 
     def check(self, ingoing_part_qns, outgoing_part_qns, interaction_qns):
-        """ implements :math:`G_{in} = G_{out}` """
+        """Implements :math:`G_{in} = G_{out}`."""
         gparity_label = StateQuantumNumberNames.Gparity
         no_gpar_inpart = [ingoing_part_qns.index(x)
                           for x in ingoing_part_qns if gparity_label not in x
@@ -459,7 +461,7 @@ class IdenticalParticleSymmetrization(AbstractRule):
 class SpinConservation(AbstractRule):
     """
     Implements conservation of a spin-like quantum number for a two body decay
-    (coupling of two particle states). See :py:meth:`check` for details.
+    (coupling of two particle states). See :meth:`check` for details.
     """
 
     def __init__(self, spinlike_qn, use_projection=True):

--- a/pycompwa/expertsystem/state/particle.py
+++ b/pycompwa/expertsystem/state/particle.py
@@ -21,6 +21,41 @@ from ..topology.graph import (
     get_originating_final_state_edges)
 
 
+__all__ = [
+    'AbstractQNConverter',
+    'CompareGraphElementPropertiesFunctor',
+    'FloatQNConverter',
+    'IntQNConverter',
+    'InteractionQuantumNumberNames',
+    'ParticleDecayPropertyNames',
+    'ParticlePropertyNames',
+    'QuantumNumberClasses',
+    'Spin',
+    'SpinQNConverter',
+    'StateQuantumNumberNames',
+    'add_to_particle_list',
+    'calculate_combinatorics',
+    'check_if_spin_projections_set',
+    'check_qns_equal',
+    'compare_qns',
+    'create_spin_domain',
+    'get_interaction_property',
+    'get_particle_candidates_for_state',
+    'get_particle_copy_by_name',
+    'get_particle_property',
+    'get_particle_with_name',
+    'get_xml_label',
+    'initialize_allowed_particle_list',
+    'initialize_edges',
+    'initialize_external_edge_lists',
+    'initialize_graph',
+    'initialize_graphs_with_particles',
+    'load_particle_list_from_xml',
+    'merge_qn_props',
+    'particle_list',
+    'populate_edge_with_spin_projections',
+]
+
 XMLLabelConstants = Enum('XMLLabelConstants',
                          'Name Pid Type Value QuantumNumber Class Projection \
                           Component Parameter PreFactor DecayInfo')
@@ -235,15 +270,14 @@ def is_boson(qn_dict):
     return abs(qn_dict[spin_label].magnitude() % 1) < 0.01
 
 
-particle_list = {}
+particle_list = dict()
 
 
 def load_particle_list_from_xml(file_path):
     """
-    By default, the expert system loads the
-    ``particle_list``
+    By default, the expert system loads the ``particle_list``
     from the XML file ``particle_list.xml`` located in the ComPWA module.
-    Use ``load_particle_list_from_xml`` to append to the ``particle_list``.
+    Use `.load_particle_list_from_xml` to append to the ``particle_list``.
     .. note::
     If a particle name in the loaded XML file already exists in the
     ``particle_list``, the one in the ``particle_list`` will be overwritten.
@@ -281,8 +315,8 @@ def get_particle_with_name(particle_name):
 
 def get_particle_copy_by_name(particle_name):
     """
-    Get a ``deepcopy`` of a particle from the ``particle_list`` dictionary so
-    you can manipulate it and add it to the particle data base.
+    Get a `~copy.deepcopy` of a particle from the ``particle_list``
+    dictionary so you can manipulate it and add it to the particle data base.
     """
     return deepcopy(particle_list[particle_name])
 

--- a/pycompwa/expertsystem/state/particle.py
+++ b/pycompwa/expertsystem/state/particle.py
@@ -20,42 +20,6 @@ from ..topology.graph import (
     get_originating_initial_state_edges,
     get_originating_final_state_edges)
 
-
-__all__ = [
-    'AbstractQNConverter',
-    'CompareGraphElementPropertiesFunctor',
-    'FloatQNConverter',
-    'IntQNConverter',
-    'InteractionQuantumNumberNames',
-    'ParticleDecayPropertyNames',
-    'ParticlePropertyNames',
-    'QuantumNumberClasses',
-    'Spin',
-    'SpinQNConverter',
-    'StateQuantumNumberNames',
-    'add_to_particle_list',
-    'calculate_combinatorics',
-    'check_if_spin_projections_set',
-    'check_qns_equal',
-    'compare_qns',
-    'create_spin_domain',
-    'get_interaction_property',
-    'get_particle_candidates_for_state',
-    'get_particle_copy_by_name',
-    'get_particle_property',
-    'get_particle_with_name',
-    'get_xml_label',
-    'initialize_allowed_particle_list',
-    'initialize_edges',
-    'initialize_external_edge_lists',
-    'initialize_graph',
-    'initialize_graphs_with_particles',
-    'load_particle_list_from_xml',
-    'merge_qn_props',
-    'particle_list',
-    'populate_edge_with_spin_projections',
-]
-
 XMLLabelConstants = Enum('XMLLabelConstants',
                          'Name Pid Type Value QuantumNumber Class Projection \
                           Component Parameter PreFactor DecayInfo')

--- a/pycompwa/expertsystem/ui/system_control.py
+++ b/pycompwa/expertsystem/ui/system_control.py
@@ -210,22 +210,22 @@ def check_equal_ignoring_qns(ref_graph, solutions, ignored_qn_list):
 
 def filter_graphs(graphs, filters):
     """
-    Implements filtering of a list of :py:class:`.StateTransitionGraph` 's.
+    Implements filtering of a list of :class:`.StateTransitionGraph` 's.
 
     This function can be used to select a subset of
-    :py:class:`.StateTransitionGraph` 's from a list. Only the graphs passing
+    :class:`.StateTransitionGraph` 's from a list. Only the graphs passing
     all supplied filters will be returned.
 
     Note:
         For the more advanced user, lambda functions can be used as filters.
 
     Args:
-        graphs ([:py:class:`.StateTransitionGraph`]): list of graphs to be
+        graphs ([:class:`.StateTransitionGraph`]): list of graphs to be
             filtered
         filters ([function]): list of functions, which take a single
-            :py:class:`.StateTransitionGraph` as an argument
+            :class:`.StateTransitionGraph` as an argument
     Returns:
-        [:py:class:`.StateTransitionGraph`]: filtered list of graphs
+        [:class:`.StateTransitionGraph`]: filtered list of graphs
 
     Example:
         Selecting only the solutions, in which the :math:`\\rho` decays via
@@ -248,7 +248,7 @@ def require_interaction_property(ingoing_particle_name,
                                  interaction_qn, allowed_values):
     """
     Closure, which can be used as a filter function in
-    :py:func:`.filter_graphs`.
+    :func:`.filter_graphs`.
 
     It selects graphs based on a requirement on the property of specific
     interaction nodes.
@@ -256,7 +256,7 @@ def require_interaction_property(ingoing_particle_name,
     Args:
         ingoing_particle_name (str): name of particle, used to find nodes which
             have a particle with this name as "ingoing"
-        interaction_qn (:py:class:`.InteractionQuantumNumberNames`):
+        interaction_qn (:class:`.InteractionQuantumNumberNames`):
             interaction quantum number
         allowed_values (list): list of allowed values, that the interaction
             quantum number may take

--- a/pycompwa/plotting/__init__.py
+++ b/pycompwa/plotting/__init__.py
@@ -1,7 +1,7 @@
 """
 .. deprecated::
     Will be migrated to `pandas.DataFrame
-    <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`__
+    <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html>`_
 """
 
 import logging


### PR DESCRIPTION
Implements three Sphinx tools/options and fixes code where necessary:

* Set `default_role` and `primary_domain` so that any text surrounded by single \`'s are determined as a domain as well. This allows one to simplify references to APIs and enforce proper use of \` in reST.
* `intersphinx` to enable cross-references to external APIs
* `nitpicky` to enforce warnings when cross-references are undefined