### PR TITLE
ci: increase travis job speed and reduce config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 os: linux
+dist: bionic # default
 
 branches:
   only:
@@ -61,6 +62,7 @@ jobs:
         - cd $BASEPATH
         - openssl aes-256-cbc -K $encrypted_ffa3dff63372_key -iv $encrypted_ffa3dff63372_iv -in github_deploy_key.enc -out github_deploy_key -d
       deploy:
+        strategy: git # default
         provider: pages
         keep_history: true
         deploy_key: github_deploy_key

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
         - ln -s ../build/ui*.so
         - cd $BASEPATH/doc
         - make linkcheck
-        - make html
+        - NBSPHINX_EXECUTE='' make html
       before_deploy:
         - cd $BASEPATH
         - openssl aes-256-cbc -K $encrypted_ffa3dff63372_key -iv $encrypted_ffa3dff63372_iv -in github_deploy_key.enc -out github_deploy_key -d

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,17 +56,40 @@ jobs:
       script:
         - echo "The tests can't run on mac osx because of a wrong RPATH in the precompiled root binaries"
 
-    - os: linux # test gcc build (Linux) + deploy pages
+    - os: linux # test gcc build (Linux)
       dist: bionic
       compiler: gcc
       env:
-        - TASK="gcc7, ROOT v6.18 + deploy pages"
+        - TASK="gcc7, ROOT v6.18"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      before_script:
-        - python3 -m pip install -r doc/requirements.txt
       script:
         - cd $BASEPATH/tests
         - python -m pytest
+
+    - os: linux # test and deploy documentation
+      dist: bionic
+      compiler: gcc
+      env:
+        - TASK="test and deploy documentation"
+        - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
+      install:
+        - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
+        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
+        - source root/bin/thisroot.sh
+        - cd $BASEPATH
+        - python3 -m pip install -r requirements.txt
+        - python3 -m pip install -r doc/requirements.txt
+        - python3 -m pip install virtualenvwrapper
+      script: # developer mode install
+        - cd $BASEPATH
+        - source venv/bin/virtualenvwrapper.sh
+        - add2virtualenv $BASEPATH
+        - mkdir build
+        - cd build
+        - cmake .. -DUSE_GENEVA=OFF -DPYTHON_EXECUTABLE=$(which python)
+        - make -j2
+        - cd $BASEPATH/pycompwa
+        - ln -s ../build/ui*.so
         - cd $BASEPATH/doc
         - make linkcheck
         - make html
@@ -106,7 +129,9 @@ jobs:
       env:
         - TASK="deployment"
       install: echo "Skipping install stage!"
+      before_install: echo "Skipping before_install stage!"
       script: echo "Skipping script stage!"
+      before_script: echo "Skipping before_script stage!"
       deploy:
         - provider: pypi # Upload new release on pypi for each tagged commit
           on: # Make sure that the version number in setup.py is

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,20 @@ env:
     - BASEPATH: "$TRAVIS_BUILD_DIR"
     - ROOTSYS: "$BASEPATH/root"
 
+addons:
+  homebrew:
+    packages:
+      - boost
+      - python3
+      - pip3
+  apt:
+    update: true
+    packages:
+      - libboost-all-dev
+      - python3
+      - python3-pip
+      - python3-venv
+
 before_install:
   - cd $BASEPATH
   - python3 -m venv venv
@@ -33,12 +47,6 @@ jobs:
   include:
     - os: osx # test XCode build
       osx_image: xcode10.2
-      addons:
-        homebrew:
-          packages:
-            - boost
-            - python3
-            - pip3
       env:
         - TASK="clang, ROOT v6.18"
         - ROOTBIN="v6.18.04.macosx64-10.14-clang100"
@@ -104,14 +112,6 @@ jobs:
       env:
         - TASK="clang, ROOT v6.18 + code coverage"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      addons:
-        apt:
-          update: true
-          packages:
-            - libboost-all-dev
-            - python3
-            - python3-pip
-            - python3-venv
       install:
         - python3 -m pip install scikit-build
         - python3 -m pip install pytest==5.4.1
@@ -134,13 +134,6 @@ jobs:
       dist: bionic
       env:
         - TASK="deployment"
-      addons:
-        apt:
-          update: true
-          packages:
-            - python3
-            - python3-pip
-            - python3-venv
       install: echo "Skipping install stage!"
       script: echo "Skipping script stage!"
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,14 @@ env:
 
 before_install:
   - cd $BASEPATH
-  - python3 -m venv python-venv
-  - source ./python-venv/bin/activate
+  - python3 -m venv venv
+  - source ./venv/bin/activate
 
 install:
-  - cd $BASEPATH
-  - cmake --version
-  - pip install scikit-build
-  - pip install -r doc/requirements.txt
-  - pip install -r requirements_dev.txt
-  - pip install codecov
+  - python3 -m pip install scikit-build
+  - python3 -m pip install pytest==5.4.1
+  - python3 -m pip install pytest-cov
+  - python3 -m pip install scipy
   - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
   - tar xpvfz root_*.tar.gz > /dev/null 2>&1
   - source root/bin/thisroot.sh
@@ -65,6 +63,15 @@ jobs:
             - python3-pip
             - python3-venv
             - pandoc
+      install:
+        - python3 -m pip install scikit-build
+        - python3 -m pip install pytest==5.4.1
+        - python3 -m pip install pytest-cov
+        - python3 -m pip install scipy
+        - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
+        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
+        - source root/bin/thisroot.sh
+        - python3 -m pip install -r doc/requirements.txt
       script:
         - cd $BASEPATH
         - python setup.py  --generator "Unix Makefiles" --skip-generator-test install
@@ -105,6 +112,15 @@ jobs:
             - python3
             - python3-pip
             - python3-venv
+      install:
+        - python3 -m pip install scikit-build
+        - python3 -m pip install pytest==5.4.1
+        - python3 -m pip install pytest-cov
+        - python3 -m pip install scipy
+        - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
+        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
+        - source root/bin/thisroot.sh
+        - python3 -m pip install codecov
       script:
         - cd $BASEPATH
         - python setup.py --generator "Unix Makefiles" --skip-generator-test install

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,8 @@ install:
   - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
   - tar xpvfz root_*.tar.gz > /dev/null 2>&1
   - source root/bin/thisroot.sh
+  - cd $BASEPATH
+  - python3 setup.py  --generator "Unix Makefiles" --skip-generator-test install -- -- -j2
 
 jobs:
   include:
@@ -52,10 +54,7 @@ jobs:
         - TASK="clang, ROOT v6.18"
         - ROOTBIN="v6.18.04.macosx64-10.14-clang100"
       script:
-        - cd $BASEPATH
-        - python setup.py  --generator "Unix Makefiles" --skip-generator-test install
-          -- -- -j2
-        # The test fails on mac osx because of a wrong RPATH in the precompiled root binaries
+        - echo "The tests can't run on mac osx because of a wrong RPATH in the precompiled root binaries"
 
     - os: linux # test gcc build (Linux) + deploy pages
       dist: bionic
@@ -66,9 +65,6 @@ jobs:
       before_script:
         - python3 -m pip install -r doc/requirements.txt
       script:
-        - cd $BASEPATH
-        - python setup.py  --generator "Unix Makefiles" --skip-generator-test install
-          -- -- -j2
         - cd $BASEPATH/tests
         - python -m pytest
         - cd $BASEPATH/doc
@@ -100,9 +96,6 @@ jobs:
       before_script:
         - python3 -m pip install codecov
       script:
-        - cd $BASEPATH
-        - python setup.py --generator "Unix Makefiles" --skip-generator-test install
-          -- -- -j2
         - cd $BASEPATH/tests
         - python -m pytest
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,22 @@ env:
     - BASEPATH: "$TRAVIS_BUILD_DIR"
     - ROOTSYS: "$BASEPATH/root"
 
+before_install:
+  - cd $BASEPATH
+  - python3 -m venv python-venv
+  - source ./python-venv/bin/activate
+
+install:
+  - cd $BASEPATH
+  - cmake --version
+  - pip install scikit-build
+  - pip install -r doc/requirements.txt
+  - pip install -r requirements_dev.txt
+  - pip install codecov
+  - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
+  - tar xpvfz root_*.tar.gz > /dev/null 2>&1
+  - source root/bin/thisroot.sh
+
 jobs:
   include:
     - os: osx # test XCode build
@@ -120,21 +136,3 @@ jobs:
           username: __token__
           password:
             secure: bvlu0vG8oOYgLbNRkbZT5QO8AQDRlMuHPUn4U7PIECzQNjFC31Y8ugXTQOPdcNsACc8TR3z52uZ1JmuK4XI9++7HuzRwhMgKziCEwD/fBdZETxXq95LorbMaD8qOY43v5vJAeFDzouDoP3iBVTpJG3dZPk7OrHy0uSSGYnC0M/WqoFg/3Lfg5tlKz8doBbgGVG/vY/58GyDxu3GcSVg7c3A4CNYKk6FwXwbWo7itTzXMJFjWmlolFtNv9m4b4gLrPSvUf7A/BrovC9IYic2N+T/KnbVOBopQ9ggk+uf1eMv1emruNiqUaJ963DMPjE154hbR7Ykvz4ng/CsvI8enmiPg18RoS1DLGxe7LVr0RzZaGsW0gw8q6H6Noc0FzNXwLb5+fDWHJtz87rrVmZZz+ofVpo370Q9y7B6joJ5EBDxPwi/Ef9MBZMEMR1pArX9rnlkVpPit0nvsb+R4e5ZS5CHj7ArSxio5pXLMrEtJyJKpnaeCbjIp5b+UfsVwSbY6i3UpE0HSHDW/Nic02/d9PfgxuBkEp6jb30yajsfWroMpJQyKD/X1qIUO48deUO79Mnu33EGWnccYBbmhMxFNCQnfLVPwKAQm7YM1/WlUa6ictifxlLouG8wZjAUviBcvTjzDY53UUpS/PIkGPL9MrqjLJbsR0XwAwp4leprngyY=
-
-before_install:
-  - cd $BASEPATH
-  - python3 -m venv python-venv
-  - source ./python-venv/bin/activate
-
-install:
-  - cd $BASEPATH
-  - cmake --version
-  - pip install scikit-build
-  - pip install -r doc/requirements.txt
-  - pip install -r requirements_dev.txt
-  - pip install codecov
-  - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
-  - tar xpvfz root_*.tar.gz > /dev/null 2>&1
-  - cd root
-  - source bin/thisroot.sh
-  - cd $BASEPATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,7 @@ jobs:
       env:
         - TASK="gcc7, ROOT v6.18 + deploy pages"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      install:
-        - python3 -m pip install scikit-build
-        - python3 -m pip install pytest==5.4.1
-        - python3 -m pip install pytest-cov
-        - python3 -m pip install scipy
-        - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
-        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
-        - source root/bin/thisroot.sh
+      before_script:
         - python3 -m pip install -r doc/requirements.txt
       script:
         - cd $BASEPATH
@@ -104,14 +97,7 @@ jobs:
       env:
         - TASK="clang, ROOT v6.18 + code coverage"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      install:
-        - python3 -m pip install scikit-build
-        - python3 -m pip install pytest==5.4.1
-        - python3 -m pip install pytest-cov
-        - python3 -m pip install scipy
-        - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
-        - tar xpvfz root_*.tar.gz > /dev/null 2>&1
-        - source root/bin/thisroot.sh
+      before_script:
         - python3 -m pip install codecov
       script:
         - cd $BASEPATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ addons:
       - python3-venv
       - pandoc
 
-before_install:
+before_install: # activate virtual environment
   - cd $BASEPATH
   - python3 -m venv venv
   - source ./venv/bin/activate
 
-install:
+install: # install dependencies
   - python3 -m pip install scikit-build
   - python3 -m pip install pytest==5.4.1
   - python3 -m pip install pytest-cov
@@ -43,6 +43,8 @@ install:
   - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
   - tar xpvfz root_*.tar.gz > /dev/null 2>&1
   - source root/bin/thisroot.sh
+
+before_script: # build the project
   - cd $BASEPATH
   - python3 setup.py  --generator "Unix Makefiles" --skip-generator-test install -- -- -j2
 
@@ -80,7 +82,8 @@ jobs:
         - python3 -m pip install -r requirements.txt
         - python3 -m pip install -r doc/requirements.txt
         - python3 -m pip install virtualenvwrapper
-      script: # developer mode install
+      before_script: echo "Running developer mode installation"
+      script: # developer mode build
         - cd $BASEPATH
         - source venv/bin/virtualenvwrapper.sh
         - add2virtualenv $BASEPATH
@@ -116,13 +119,12 @@ jobs:
       env:
         - TASK="clang, ROOT v6.18 + code coverage"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      before_script:
-        - python3 -m pip install codecov
       script:
         - cd $BASEPATH/tests
         - python -m pytest
       after_success:
-        - python -m codecov
+        - python3 -m pip install codecov
+        - python3 -m codecov
 
     - os: linux # deploy pip package
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ addons:
       - python3
       - python3-pip
       - python3-venv
+      - pandoc
 
 before_install:
   - cd $BASEPATH
@@ -62,15 +63,6 @@ jobs:
       env:
         - TASK="gcc7, ROOT v6.18 + deploy pages"
         - ROOTBIN="v6.18.04.Linux-ubuntu18-x86_64-gcc7.4"
-      addons:
-        apt:
-          update: true
-          packages:
-            - libboost-all-dev
-            - python3
-            - python3-pip
-            - python3-venv
-            - pandoc
       install:
         - python3 -m pip install scikit-build
         - python3 -m pip install pytest==5.4.1

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
-doc8
+doc8==0.8.0
 jupyter
-nbsphinx
+nbsphinx==0.5.1
 sphinx-copybutton
-sphinx>=2.2.0
+sphinx==2.4.4
 sphinx_rtd_theme
 uproot

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -138,7 +138,7 @@ linkcheck_ignore = [
 ]
 
 # Settings for nbsphinx
-if 'TRAVIS' in os.environ or 'NBSPHINX_EXECUTE' in os.environ:
+if 'NBSPHINX_EXECUTE' in os.environ:
     nbsphinx_execute = 'always'
 else:
     nbsphinx_execute = 'never'

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -48,8 +48,7 @@ You will then need to set some symbolic links to the Python module of pycompwa:
 .. code-block:: shell
 
   cd ../pycompwa
-  ln -s ../build/ui.*.so .
-  ln -s ../ComPWA/Physics/particle_list.xml .
+  ln -s ../build/ui.*.so
 
 Finally, you can tell Conda where to locate the pycompwa package, so that the
 Python interpreter understand the ``import pycompwa`` command. You do this with:

--- a/pycompwa/particle_list.xml
+++ b/pycompwa/particle_list.xml
@@ -1,0 +1,1 @@
+../ComPWA/Physics/particle_list.xml

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,7 @@ jupyter_contrib_nbextensions
 pep8-naming
 pre-commit==2.2.0
 pylint==2.4.4
-pytest
+pytest==5.4.1
 pytest-cov
 scipy
-tox
+tox==3.14.6

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except SKBuildError:
 
 setup(
     name='pycompwa',
-    version='0.1.00',
+    version='0.1.0',
     author='The ComPWA team',
     maintainer_email="compwa-admin@ep1.rub.de",
     url="https://github.com/ComPWA/pycompwa",


### PR DESCRIPTION
The travis gcc task is much slower than the other tasks, because it also builds the documentation (and runs the notebooks). This has been split into a separate task now.

In addition, errors started popping up in the doc building because travis installs sphinx 3.0.0. So the versions of developer tools have been fixed now.