### PR TITLE
docs: split up installation instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,7 @@ before_install: # activate virtual environment
 
 install: # install dependencies
   - python3 -m pip install scikit-build
-  - python3 -m pip install pytest==5.4.1
-  - python3 -m pip install pytest-cov
-  - python3 -m pip install scipy
+  - python3 -m pip install -r tests/requirements.txt
   - wget https://root.cern.ch/download/root_${ROOTBIN}.tar.gz
   - tar xpvfz root_*.tar.gz > /dev/null 2>&1
   - source root/bin/thisroot.sh

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,4 +4,3 @@ nbsphinx==0.5.1
 sphinx-copybutton
 sphinx==2.4.4
 sphinx_rtd_theme
-uproot

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -129,7 +129,6 @@ intersphinx_mapping = {
 
 # Settings for autosectionlabel
 autosectionlabel_prefix_document = True
-autosectionlabel_maxdepth = 1
 
 # Settings for linkcheck
 linkcheck_anchors = False

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -11,13 +11,12 @@ Python developer tools
 ^^^^^^^^^^^^^^^^^^^^^^
 
 For contributing to pycompwa, we recommend you also install the packages listed
-under `requirements_dev.txt
-<https://github.com/ComPWA/pycompwa/blob/master/requirements_dev.txt>`_. In
-the Conda environment you created for pycompwa:
+under :download:`requirements-dev.txt <../../requirements-dev.txt>`. In the
+Conda environment you created for pycompwa:
 
 .. code-block:: shell
 
-  conda install --file requirements_dev.txt
+  conda install --file requirements-dev.txt
 
 An important tool there is `pre-commit <https://pre-commit.com/>`_. This will
 run certain tests locally when you make a Git commit. To activate, run the

--- a/doc/source/contribute.rst
+++ b/doc/source/contribute.rst
@@ -5,61 +5,6 @@
 How to contribute
 =================
 
-.. _Developer Mode:
-
-Developer Mode
---------------
-
-If you want to develop new functionality for pycompwa, installing pycompwa as a
-pip or Conda package will not suffice: you will have to **build from source**,
-so that you can continuously implement updates. In this 'developer mode', you
-still work in a Conda environment (see :doc:`installation`, especially for the
-`Conda-Forge <https://conda-forge.org/>`_ instructions), but now you install
-the :mod:`pycompwa` package from the cloned repository using `conda-develop
-<https://docs.conda.io/projects/conda-build/en/latest/resources/commands/conda-develop.html>`_,
-so that any changes you make in the source code immediately have effect.
-
-First, clone the pycompwa repository recursively to some suitable folder (you
-can omit the ``<PYCOMPWA_SOURCE_PATH>``):
-
-.. code-block:: shell
-
-  git clone --recurse-submodules git@github.com:ComPWA/pycompwa.git <PYCOMPWA_SOURCE_PATH>
-
-Now, go into the cloned repository, create a new Conda environment for
-pycompwa with the necessary packages installed, and activate it:
-
-.. code-block:: shell
-
-  conda create -n compwa --file requirements.txt
-  conda activate compwa
-
-You can now build the pycompwa package from source:
-
-.. code-block:: shell
-
-  mkdir -p build
-  cd build
-  cmake ..
-  cmake --build . -- -j4  # adjust 4 to your number of cores
-
-You will then need to set some symbolic links to the Python module of pycompwa:
-
-.. code-block:: shell
-
-  cd ../pycompwa
-  ln -s ../build/ui.*.so
-
-Finally, you can tell Conda where to locate the pycompwa package, so that the
-Python interpreter understand the ``import pycompwa`` command. You do this with:
-
-.. code-block:: shell
-
-  conda develop <PYCOMPWA_SOURCE_PATH>
-
-where ``<PYCOMPWA_SOURCE_PATH>`` refers to the absolute or relative path of the
-cloned pycompwa repository.
-
 .. _python-dev-tools:
 
 Python developer tools

--- a/doc/source/install/build.rst
+++ b/doc/source/install/build.rst
@@ -41,9 +41,10 @@ Developer Mode
 ~~~~~~~~~~~~~~
 
 In this set-up, we first tell the virtual environment to monitor the source
-code directory as an install directory. So, navigate to the :doc:`local
-repository <get-the-source-code>` then, depending on which :doc:`virtual
-environment </install/virtual-environment>` you chose, do the following:
+code directory as an install directory. So, navigate to the base folder of the
+:doc:`local repository <get-the-source-code>` then, depending on which
+:doc:`virtual environment </install/virtual-environment>` you chose, do the
+following:
 
 .. code-block:: shell
   :caption: if you :ref:`use a Conda environment

--- a/doc/source/install/build.rst
+++ b/doc/source/install/build.rst
@@ -33,8 +33,8 @@ This is easy-peasy! Just navigate to the :doc:`local repository
   python setup.py install -- -- -j2
 
 where you may change 2 to to the number of cores on your system. The build
-output is written to a folder :file:`_skbuild` and copied to an installation
-folder known to the virtual environment.
+output is written to a folder :file:`_skbuild` and copied to the virtual
+environment directory.
 
 
 Developer Mode

--- a/doc/source/install/build.rst
+++ b/doc/source/install/build.rst
@@ -1,0 +1,98 @@
+Build and install
+=================
+
+Once you :doc:`have the source code <get-the-source-code>` and have
+:doc:`activated the virtual environment <virtual-environment>`, you're ready to
+build and install `pycompwa`.
+
+When you install `pycompwa`, you are telling the system where to find it. There
+are two ways of doing this:
+
+(1) by copying the source code and binaries to a folder known to the system
+    (you do this :ref:`with setuptools <setuptools>`)
+(2) by telling the system to directly monitor the :doc:`local repository
+    <get-the-source-code>` as the installation path (we call this
+    :ref:`'developer mode' <install/build:Developer Mode>`).
+
+The second option is more dynamic, because any changes to the source code are
+immediately available at runtime, which allows you to tweak the code and try
+things out. When using the first option, you would have to run ``setuptools``
+again to make the changes known to the system.
+
+
+.. _setuptools:
+
+Using ``setuptools``
+~~~~~~~~~~~~~~~~~~~~
+
+This is easy-peasy! Just navigate to the :doc:`local repository
+<get-the-source-code>` and run:
+
+.. code-block:: shell
+
+  python setup.py install -- -- -j2
+
+where you may change 2 to to the number of cores on your system. The build
+output is written to a folder :file:`_skbuild` and copied to a system folder
+from there.
+
+
+Developer Mode
+~~~~~~~~~~~~~~
+
+In this set-up, we first tell the virtual environment to monitor the source
+code directory as an install directory. So, navigate to the :doc:`local
+repository <get-the-source-code>` then, depending on which :doc:`virtual
+environment </install/virtual-environment>` you chose, do the following:
+
+.. code-block:: shell
+  :caption: if you :ref:`use a Conda environment
+    <install/virtual-environment:Conda environment>`
+
+  conda develop .
+
+.. code-block:: shell
+  :caption: if you :ref:`use Python venv <install/virtual-environment:Python
+    venv>`
+
+  pip install virtualenvwrapper
+  source venv/bin/virtualenvwrapper.sh
+  add2virtualenv .
+
+We now call `cmake <https://cmake.org/>`_ directly to build the `ComPWA backend
+<https://github.com/ComPWA/ComPWA>`_:
+
+.. code-block:: shell
+
+  mkdir -p build
+  cd build
+  cmake ..
+  cmake --build . -- -j2
+
+The most important binary build file is the shared library for the
+`pycompwa.ui` package. You need to set a symbolic link to this file from the
+:file:`pycompwa` source code folder:
+
+.. code-block:: shell
+
+  cd ../pycompwa
+  rm -f ui.*.so  # in case you already created a symlink
+  ln -s ../build/ui.*.so
+
+
+Test the installation
+~~~~~~~~~~~~~~~~~~~~~
+
+First, navigate out of the main directory of the :doc:`local repository
+<get-the-source-code>` in order to make sure that the `pycompwa` we run is the
+system installation and not the :file:`pycompwa` folder in the current working
+directory. Then, simply launch launch a Python interpreter and run:
+
+.. code-block:: python
+
+  import pycompwa
+
+If you don't get any error messages, all worked out nicely!
+
+You can now go through the :doc:`/usage/workflow` to learn how to use
+:mod:`pycompwa`.

--- a/doc/source/install/build.rst
+++ b/doc/source/install/build.rst
@@ -94,5 +94,13 @@ directory. Then, simply launch launch a Python interpreter and run:
 
 If you don't get any error messages, all worked out nicely!
 
+For more thorough testing you can run the unit tests:
+
+.. code-block:: shell
+
+  cd tests
+  pip install -r requirements.txt
+  pytest -m "not slow"
+
 You can now go through the :doc:`/usage/workflow` to learn how to use
 :mod:`pycompwa`.

--- a/doc/source/install/build.rst
+++ b/doc/source/install/build.rst
@@ -33,8 +33,8 @@ This is easy-peasy! Just navigate to the :doc:`local repository
   python setup.py install -- -- -j2
 
 where you may change 2 to to the number of cores on your system. The build
-output is written to a folder :file:`_skbuild` and copied to a system folder
-from there.
+output is written to a folder :file:`_skbuild` and copied to an installation
+folder known to the virtual environment.
 
 
 Developer Mode

--- a/doc/source/install/get-the-source-code.rst
+++ b/doc/source/install/get-the-source-code.rst
@@ -1,0 +1,31 @@
+Get the source code
+===================
+
+After you have :ref:`installed the prerequisites <installation:Prerequisites>`,
+use `Git <https://git-scm.com/>`_ to get a copy of the `pycompwa source code
+<http://github.com/ComPWA/pycompwa>`_. To do so, navigate to a suitable folder
+and run:
+
+.. code-block:: shell
+
+  git clone --recurse-submodules git@github.com:ComPWA/pycompwa.git
+
+This will take a few minutes, because the source code for ComPWA and its
+submodules will also be downloaded.
+
+After that, there should be a folder called :file:`pycompwa`. We'll call this
+folder the **local repository**. If you navigate into it, you can see it has:
+
+* a `pycompwa <https://github.com/ComPWA/pycompwa/tree/master/pycompwa>`_
+  folder with Python source code
+* a `ComPWA <https://github.com/ComPWA/ComPWA/>`_ folder with C++ source code
+* a `requirements.txt <https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`_
+  file listing the Python dependencies
+* a `setup.py <https://github.com/ComPWA/pycompwa/blob/master/setup.py>`_ file
+  with instructions for :ref:`setuptools <setuptools>`
+* a `CMakeLists.txt
+  <https://github.com/ComPWA/pycompwa/blob/master/CMakeLists.txt>`_ file for if
+  you build with `cmake <https://cmake.org/>`_ (in :ref:`developer mode
+  <install/build:Developer Mode>`)
+
+These files will be used in the following steps.

--- a/doc/source/install/get-the-source-code.rst
+++ b/doc/source/install/get-the-source-code.rst
@@ -29,3 +29,20 @@ folder the **local repository**. If you navigate into it, you can see it has:
   <install/build:Developer Mode>`)
 
 These files will be used in the following steps.
+
+.. note::
+
+  When new commits are merged into the `master branch of pycompwa
+  <https://github.com/ComPWA/pycompwa/tree/master>`_, you need to update your
+  local copy of the source code. It's important that you also update the
+  submodules:
+
+  .. code-block:: shell
+
+    git checkout master
+    git pull --recurse-submodules
+
+  It's best to have a clean your working tree before you do a :command:`git
+  pull`. See :doc:`/contribute` for more info.
+
+  Once you have the update, don't forget to :doc:`rebuild pycompwa <build>`!

--- a/doc/source/install/virtual-environment.rst
+++ b/doc/source/install/virtual-environment.rst
@@ -1,0 +1,82 @@
+Create a virtual environment
+============================
+
+It is safest to install `pycompwa` within a virtual environment, so that all
+Python dependencies are contained within there. This is helpful in case
+something goes wrong with the dependencies: you can just trash the environment
+and recreate it. There are two options: :ref:`Conda
+<install/virtual-environment:Conda environment>` or :ref:`Python's venv
+<install/virtual-environment:Python venv>`.
+
+Conda environment
+^^^^^^^^^^^^^^^^^
+
+`Conda <https://www.anaconda.com/>`_ can be installed without administrator
+rights, see instructions on `this page
+<https://www.anaconda.com/distribution/>`_. Once installed, you can use the
+:file:`environment.yml` file from the :doc:`local repository
+<get-the-source-code>` to create a Conda environment for the `pycompwa`
+installation:
+
+.. code-block:: shell
+
+  conda env create -f environment.yml
+
+This command will take a few minutes, because all required dependencies will be
+installed in one go through `pip <https://pypi.org/project/pip/>`_. After Conda
+finishes creating the environment, you can activate it with as follows:
+
+.. code-block:: shell
+
+  conda activate pwa
+
+You need to have the ``pwa`` environment activated whenever you want to run
+`pycompwa`.
+
+.. hint::
+
+  You can automatically source your ROOT installation upon activating the
+  ``pwa`` environment by `adding an activate script
+  <https://docs.conda.io/projects/conda-build/en/latest/resources/activate-scripts.html>`_.
+  It's neat to have a deactivate script as well. Under linux, this would be:
+
+  .. code-block:: shell
+    :caption: ~/anaconda3/envs/pwa/etc/conda/**activate.d**/cern_root.sh
+
+    #!/usr/bin/env bash
+    source "<path to you ROOT installation>/bin/thisroot.sh"
+
+  .. code-block:: shell
+    :caption: ~/anaconda3/envs/pwa/etc/conda/**deactivate.d**/cern_root.sh
+
+    #!/usr/bin/env bash
+    unset ROOTSYS
+
+Python venv
+^^^^^^^^^^^
+
+Alternatively, you can use `Python's venv
+<https://docs.python.org/3/library/venv.html>`_. All you have to do, is
+navigate into :doc:`local repository <get-the-source-code>` and run:
+
+.. code-block:: shell
+
+  python3 -m venv ./venv
+
+This creates a folder called :file:`venv` where all Python packages will be
+contained. You first have to activate the environment, and will have to do so
+whenever you want to run those Python packages.
+
+.. code-block:: shell
+
+  source ./venv/bin/activate
+
+Now you can safely install the required Python requirements through `pip
+<https://pypi.org/project/pip/>`_:
+
+.. code-block:: shell
+
+  pip install scikit-build
+  pip install -r requirements.txt
+
+That's it, now you're all set to :doc:`build and install pycompwa <build>`!

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -65,6 +65,10 @@ Et voilà, that's it! You can try out whether the installation works by running:
 from the Python interpreter. If that works, you can try out some of the
 examples from the :doc:`usage` page.
 
+Note that you can :command:`pip` **only allows you to install specific
+releases**. We therefore recommend following the :ref:`interactive installation
+<installation:Interactive installation>` procedure instead.
+
 
 Interactive installation
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -25,8 +25,9 @@ The following package are optional:
 * `GSL <https://www.gnu.org/software/gsl/>`_
 * `Geneva <https://www.gemfony.eu/>`_
 
-For basic fitting functionality, it is easiest to install ROOT `with Minuit2
-enabled <https://root.cern.ch/building-root>`_.
+It is highly recommended to install ROOT `with Minuit2 enabled
+<https://root.cern.ch/building-root>`_. Without it, ComPWA will have only
+limited functionality.
 
 .. hint::
 

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -1,79 +1,89 @@
-.. |br| raw:: html
-
-  <br />
-
 Installation
 ============
 
-It is best to install the pycompwa framework within a virtual environment, so
-that all dependencies of pycompwa are contained within there. We recommend to
-use `Anaconda <https://www.anaconda.com/distribution/>`_ in combination with
-`Conda-Forge <https://conda-forge.org/>`_.
+Prerequisites
+^^^^^^^^^^^^^
 
-After you have `installed Anaconda
-<https://docs.anaconda.com/anaconda/install/>`_, set Conda-Forge as the
-default channel as follows:
+`pycompwa` is `available as a PyPI package
+<https://pypi.org/project/pycompwa/>`_. However, since the `pycompwa.ui` module
+contains Python bindings to the `ComPWA backend
+<https://github.com/ComPWA/ComPWA>`_, you first need to install certain C++
+prerequisites.
 
-.. code-block:: shell
+What you definitely need to install, is:
 
-  conda config --add channels conda-forge
-  conda config --set channel_priority strict
+* a build tool: `cmake <https://cmake.org/>`_
+* a C++ compiler:
+  `gcc <https://gcc.gnu.org/>`_ or `clang <https://clang.llvm.org/>`_
+* `Boost <https://www.boost.org/>`_
+* `Python3 <https://www.python.org/downloads/>`_
 
-Now, create a new environment with `all required dependencies
-<https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`_
-installed:
+The following package are optional:
 
-.. code-block:: shell
+* `ROOT <https://root.cern.ch/downloading-root>`_ and/or `Minuit2
+  <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`_
+* `GSL <https://www.gnu.org/software/gsl/>`_
+* `Geneva <https://www.gemfony.eu/>`_
 
-  conda create -n compwa --file requirements.txt
+For basic fitting functionality, it is easiest to install ROOT `with Minuit2
+enabled <https://root.cern.ch/building-root>`_.
 
-Here, we call the environment ``compwa``, but you can give it any name. Now, go
-into this environment with ``conda activate compwa``, so we can install
-pycompwa there:
+.. hint::
+
+  If you have a Linux machine with `apt <https://wiki.debian.org/Apt>`_ and
+  with administrator rights, you can run the following:
+
+  .. code-block:: shell
+
+    sudo apt update -y
+    sudo apt install -y cmake gcc git libboost-all-dev python3
+
+  ROOT with Minuit2 can be most easily installed by `downloading a suitable
+  binary for your machine <https://root.cern.ch/downloading-root>`_.
+
+
+Installation through pip
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once you have these dependencies installed, you can install `pycompwa` through
+`pip <https://pypi.org/project/pip/>`_. You also need to install `scikit-build
+<https://scikit-build.readthedocs.io/en/latest/>`_, because it is used as a
+build tool for the ComPWA backend:
 
 .. code-block:: shell
 
   pip install scikit-build
   pip install pycompwa
 
-Note that ``scikit-build`` has to be installed first.
+Et voilà, that's it! You can try out whether the installation works by running:
 
-That's it! You can now go through the :doc:`usage/workflow` to learn how to use
-:mod:`pycompwa`.
+.. code-block:: python
 
-.. tip::
+  import pycompwa
 
-    Of course, pycompwa can also be used with `jupyter
-    <https://jupyter.org/>`_. You can install jupyter in your virtual Conda
-    environment via ``conda install jupyter``. Then, just navigate to the
-    `examples <https://github.com/ComPWA/pycompwa/tree/master/examples>`_
-    folder and run ``jupyter notebook``.
+from the Python interpreter. If that works, you can try out some of the
+examples from the :doc:`usage` page.
 
-Prerequisites
--------------
 
-ComPWA and the pycompwa interface have the following dependencies:
+Interactive installation
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``scikit-build`` (a python package) |br|
-  Install via ``pip install scikit-build``
-* requirements of `ComPWA <https://github.com/ComPWA/ComPWA#prerequisites>`_:
+`pycompwa` is an academic research project and is bound to continuously evolve.
+We therefore highly recommend installing `pycompwa` from `the source code
+<https://github.com/ComPWA/pycompwa>`_, so that you work with the latest
+version.
 
-  * Build tool: `cmake <https://cmake.org/>`_
-  * Compiler: ``gcc`` or ``clang``
-  * `Boost <https://www.boost.org/>`_
-  * optional libraries: |br|
-    `ROOT <https://root.cern.ch/downloading-root>`_ and/or `Minuit
-    <http://seal.web.cern.ch/seal/snapshot/work-packages/mathlibs/minuit/>`_,
-    `Geneva <https://www.gemfony.eu/>`_, and
-    `GSL <https://www.gnu.org/software/gsl/>`_
+Moreover, since you read as far as this, you must have an interest in
+partial-wave analysis, and it is researchers like you who can help bring this
+project further! So please, have a look through the following sections to set
+up this 'interactive installation':
 
-* The Python requirements listed `here
-  <https://github.com/ComPWA/pycompwa/blob/master/requirements.txt>`_
+.. toctree::
+  :maxdepth: 2
 
-Installation from source
-------------------------
+  install/get-the-source-code
+  install/virtual-environment
+  install/build
 
-If you are a pycompwa developer, you will have to build the framework from
-source instead of using the :mod:`pycompwa` release that is distributed through
-`Conda <https://docs.conda.io/>`_. See :ref:`Developer Mode` for the
-installation instructions.
+After that, it's worth having a look at the :doc:`contribute tutorials
+<contribute>`!

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -65,8 +65,8 @@ Et voilà, that's it! You can try out whether the installation works by running:
 from the Python interpreter. If that works, you can try out some of the
 examples from the :doc:`usage` page.
 
-Note that you can :command:`pip` **only allows you to install specific
-releases**. We therefore recommend following the :ref:`interactive installation
+Note that :command:`pip` **only allows you to install specific releases**. We
+therefore recommend following the :ref:`interactive installation
 <installation:Interactive installation>` procedure instead.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,10 @@
+name: pwa
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python<=3.7 # because of pybind11
+  - pip
+  - pip:
+      - scikit-build
+      - -r requirements.txt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,15 +1,15 @@
+-r doc/requirements.txt
+-r tests/requirements.txt
 autopep8==1.5
-flake8==3.7.9
 flake8-blind-except
 flake8-builtins
 flake8-docstrings
 flake8-import-order
 flake8-rst-docstrings
+flake8==3.7.9
+flake8==3.7.9
 jupyter_contrib_nbextensions
 pep8-naming
 pre-commit==2.2.0
 pylint==2.4.4
-pytest==5.4.1
-pytest-cov
-scipy
 tox==3.14.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,12 @@
 -r doc/requirements.txt
 -r tests/requirements.txt
 autopep8==1.5
+flake8==3.7.9
 flake8-blind-except
 flake8-builtins
 flake8-docstrings
 flake8-import-order
 flake8-rst-docstrings
-flake8==3.7.9
-flake8==3.7.9
 jupyter_contrib_nbextensions
 pep8-naming
 pre-commit==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ matplotlib
 numpy
 pandas
 progress
+uproot
 xmltodict

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -3,9 +3,6 @@ testpaths = .
 addopts =
     --cov=pycompwa
     --cov-config=.coveragerc
-    --durations=0
-    --cov-report=html
+    --durations=5
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-    --durations=0
-    --cov-report=html

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==5.4.1
+pytest-cov
+scipy

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 [testenv:pep8]
 passenv = PYTHONPATH
 deps =
-    -rrequirements_dev.txt
+    -rrequirements-dev.txt
 commands =
     flake8
 


### PR DESCRIPTION
Installation instructions have been made into more of a tutorial to put more emphasis on the developmental nature of the project. This is a step towards https://github.com/ComPWA/pycompwa/issues/82.

Note that instructions for `venv` have been added back to serve in parallel to the Conda instructions.

Requirements files have been split to simplify the install tutorial, which closes https://github.com/ComPWA/pycompwa/issues/81